### PR TITLE
ArgSchemaModule 

### DIFF
--- a/rendermodules/module/render_module.py
+++ b/rendermodules/module/render_module.py
@@ -127,7 +127,7 @@ class RenderModule(ArgSchemaModule):
                 'schema {} is not of type RenderParameters')
 
         # TODO do we want output schema passed?
-        super(self.__class__, self).__init__(
+        super(RenderModule, self).__init__(
             schema_type=schema_type, *args, **kwargs)
         self.render = renderapi.render.connect(**self.args['render'])
 


### PR DESCRIPTION
Base class which processes attributes default_schema and default_output_schema so that the following is valid (no custom `__init__` necessary).
There is a try/except in place to work with incompatible argschema versions without output_schema_type
```Python
class MyInput(RenderParameters):
    mystack = argschema.fields.Str(required=True)
    
class MyOutput(DefaultSchema):
    myInt = argschema.fields.Int(required=True)

class MyModule(RenderModule):
    default_schema = MyInput
    default_output_schema = MyOutput
    
    def run():
        pass

```
This also introduces a base `RenderModuleException`.