### PR TITLE
added code coverage configuration to pass when no reports found

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project: 
+      default:
+        target: auto  # this is default
+        if_not_found: success  # no commit found? still set a success


### PR DESCRIPTION
After doing some reading I have found this as a workaround so that it won't 'fail' a code coverage if it can't find a proper comparison, which will remove the sad red check marks in those cases.