### PR TITLE
altered multiplicative correction tests to include file: prefix in template

### DIFF
--- a/integration_tests/test_files/intensity_correction_template.json
+++ b/integration_tests/test_files/intensity_correction_template.json
@@ -14,8 +14,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0040_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0040_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -53,8 +53,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0024_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0024_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -92,8 +92,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0026_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0026_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -131,8 +131,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0064_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0064_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -170,8 +170,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0032_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0032_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -209,8 +209,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0071_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0071_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -248,8 +248,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0094_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0094_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -287,8 +287,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0013_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0013_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -326,8 +326,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0088_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0088_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -365,8 +365,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0075_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0075_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -404,8 +404,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0079_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0079_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -443,8 +443,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0054_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0054_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -482,8 +482,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0005_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0005_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -521,8 +521,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0008_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0008_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -560,8 +560,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0028_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0028_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -599,8 +599,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0085_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0085_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -638,8 +638,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0023_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0023_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -677,8 +677,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0097_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0097_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -716,8 +716,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0081_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0081_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -755,8 +755,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0031_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0031_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -794,8 +794,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0015_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0015_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -833,8 +833,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0091_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0091_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -872,8 +872,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0037_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0037_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -911,8 +911,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0046_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0046_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -950,8 +950,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0053_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0053_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -989,8 +989,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0083_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0083_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -1028,8 +1028,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0065_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0065_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -1067,8 +1067,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0029_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0029_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -1106,8 +1106,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0021_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0021_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -1145,8 +1145,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0034_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0034_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -1184,8 +1184,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0062_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0062_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -1223,8 +1223,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0027_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0027_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -1262,8 +1262,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0042_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0042_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -1301,8 +1301,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0066_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0066_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -1340,8 +1340,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0069_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0069_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -1379,8 +1379,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0099_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0099_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -1418,8 +1418,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0039_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0039_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -1457,8 +1457,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0014_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0014_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -1496,8 +1496,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0003_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0003_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -1535,8 +1535,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0017_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0017_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -1574,8 +1574,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0049_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0049_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -1613,8 +1613,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0092_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0092_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -1652,8 +1652,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0059_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0059_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -1691,8 +1691,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0048_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0048_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -1730,8 +1730,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0080_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0080_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -1769,8 +1769,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0051_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0051_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -1808,8 +1808,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0002_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0002_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -1847,8 +1847,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0070_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0070_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -1886,8 +1886,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0010_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0010_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -1925,8 +1925,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0045_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0045_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -1964,8 +1964,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0055_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0055_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -2003,8 +2003,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0012_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0012_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -2042,8 +2042,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0087_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0087_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -2081,8 +2081,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0030_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0030_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -2120,8 +2120,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0061_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0061_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -2159,8 +2159,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0000_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0000_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -2198,8 +2198,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0050_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0050_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -2237,8 +2237,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0072_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0072_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -2276,8 +2276,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0063_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0063_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -2315,8 +2315,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0044_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0044_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -2354,8 +2354,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0004_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0004_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -2393,8 +2393,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0084_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0084_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -2432,8 +2432,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0011_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0011_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -2471,8 +2471,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0056_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0056_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -2510,8 +2510,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0089_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0089_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -2549,8 +2549,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0067_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0067_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -2588,8 +2588,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0018_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0018_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -2627,8 +2627,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0019_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0019_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -2666,8 +2666,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0096_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0096_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -2705,8 +2705,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0052_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0052_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -2744,8 +2744,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0038_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0038_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -2783,8 +2783,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0077_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0077_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -2822,8 +2822,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0060_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0060_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -2861,8 +2861,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0022_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0022_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -2900,8 +2900,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0016_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0016_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -2939,8 +2939,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0076_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0076_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -2978,8 +2978,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0025_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0025_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -3017,8 +3017,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0074_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0074_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -3056,8 +3056,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0043_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0043_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -3095,8 +3095,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0090_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0090_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -3134,8 +3134,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0047_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0047_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -3173,8 +3173,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0033_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0033_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -3212,8 +3212,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0086_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0086_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -3251,8 +3251,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0035_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0035_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -3290,8 +3290,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0007_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0007_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -3329,8 +3329,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0098_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0098_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -3368,8 +3368,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0057_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0057_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -3407,8 +3407,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0020_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0020_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -3446,8 +3446,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0082_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0082_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -3485,8 +3485,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0058_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0058_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -3524,8 +3524,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0009_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0009_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -3563,8 +3563,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0073_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0073_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -3602,8 +3602,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0041_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0041_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -3641,8 +3641,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0078_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0078_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -3680,8 +3680,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0001_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0001_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -3719,8 +3719,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0095_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0095_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -3758,8 +3758,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0006_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0006_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -3797,8 +3797,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0036_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0036_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -3836,8 +3836,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0068_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0068_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 
@@ -3875,8 +3875,8 @@
         }, 
         "mipmapLevels": {
             "0": {
-                "imageUrl": "{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0093_Z00.tif", 
-                "maskUrl": "{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
+                "imageUrl": "file:{{test_data_root}}/intensitycorrection_test_data/raw/DAPI_1_S0000_F0093_Z00.tif", 
+                "maskUrl": "file:{{test_data_root}}/intensitycorrection_test_data/mask/fullscmos.tif"
             }
         }, 
         "height": 2048.0, 

--- a/rendermodules/dataimport/generate_mipmaps.py
+++ b/rendermodules/dataimport/generate_mipmaps.py
@@ -34,7 +34,6 @@ def create_mipmap_from_tuple(mipmap_tuple, levels=[1, 2, 3],
                              imgformat='tif', convertTo8bit=True,
                              force_redo=True):
     (filepath, downdir) = mipmap_tuple
-    print mipmap_tuple
     return create_mipmaps(filepath, outputDirectory=downdir,
                           mipmaplevels=levels, convertTo8bit=convertTo8bit,
                           outputformat=imgformat, force_redo=force_redo)

--- a/rendermodules/intensity_correction/apply_multiplicative_correction.py
+++ b/rendermodules/intensity_correction/apply_multiplicative_correction.py
@@ -7,6 +7,8 @@ import numpy as np
 import tifffile
 from ..module.render_module import RenderModule
 from rendermodules.intensity_correction.schemas import MultIntensityCorrParams
+import urllib
+import urlparse
 
 example_input = {
     "render": {
@@ -76,7 +78,9 @@ def getImage(ts):
     """
     d = ts.to_dict()
     mml = ts.ip.get(0)
-    img0 = tifffile.imread(mml['imageUrl'])
+    url = urllib.unquote(urlparse.urlparse(
+        str(mml['imageUrl'])).path)
+    img0 = tifffile.imread(url)
     (N, M) = img0.shape
     return N, M, img0
 


### PR DESCRIPTION
and also added url unquoting to fix the module.  I think we should implement a more general image reading method in render-python in order to consolidate this kind of stuff.  Should do different things automatically depending on the nature of the URL and the type of image that is found there (s3, tif, png, http, etc etc)