### PR TITLE
Int corr subsample

### DIFF
--- a/rendermodules/intensity_correction/calculate_multiplicative_correction.py
+++ b/rendermodules/intensity_correction/calculate_multiplicative_correction.py
@@ -32,8 +32,7 @@ def getImageFromTilespecs(alltilespecs, index):
     N, M, img = getImage(alltilespecs[index])
     return img
 
-def randomly_subsample_tilespecs(alltilespecs,percent):
-    numtiles = floor(len(alltilespecs)*percent/100)
+def randomly_subsample_tilespecs(alltilespecs,numtiles):
     np.random.shuffle(alltilespecs)
     return alltilespecs[:numtiles]
 
@@ -61,8 +60,8 @@ class MakeMedian(RenderModule):
             numtiles += len(tilespecs)
 
         #subsample in the case where the number of tiles is too large
-        if self.args['percent_subsample'] < 100:
-            alltilespecs = randomly_subsample_tilespecs(alltilespecs,self.args['percent_subsample'])
+        if self.args['num_images'] > 0:
+            alltilespecs = randomly_subsample_tilespecs(alltilespecs,self.args['num_images'])
 
         # read images and create stack
         N, M, img0 = getImage(alltilespecs[0])

--- a/rendermodules/intensity_correction/schemas.py
+++ b/rendermodules/intensity_correction/schemas.py
@@ -18,8 +18,8 @@ class MakeMedianParams(RenderParameters):
                     description='size of pool for parallel processing (default=20)')
     close_stack = Bool(required=False, default=False,
                        description="whether to close stack or not")
-    percent_subsample = Int (required=False,default=100,
-                             description="Percent of images to randomly subsample to generate median")
+    num_images = Int (required=False,default=-1,
+                             description="Number of images to randomly subsample to generate median")
 
 
 class MultIntensityCorrParams(RenderParameters):


### PR DESCRIPTION
I have added an option use a percentage of the tiles for median calculation. This should work in priniciple if the distribution of intensities in the tiles within a section are similar. However, in your tiles, there are sometimes significant shifts in intensities and we may want to actually calculate separate medians groups of tiles so we should discuss how we want to go about this. In the meanwhile, the new option of percent_subsample will at least allow you to run the code on a section without crashing out of memory.