### PR TITLE
Mipmaps decmods

### DIFF
--- a/integration_tests/test_dataimport.py
+++ b/integration_tests/test_dataimport.py
@@ -74,7 +74,7 @@ def outfile_test_and_remove(f, output_fn):
     assert not os.path.isfile(output_fn)
     val = f()
     assert os.path.isfile(output_fn)
-    assert os.remove(output_fn)
+    os.remove(output_fn)
     assert not os.path.isfile(output_fn)
     return val
 

--- a/integration_tests/test_dataimport.py
+++ b/integration_tests/test_dataimport.py
@@ -9,7 +9,7 @@ import renderapi
 from rendermodules.dataimport import generate_EM_tilespecs_from_metafile
 from rendermodules.dataimport import generate_mipmaps
 from rendermodules.dataimport import apply_mipmaps_to_render
-from test_data import (render_params, 
+from test_data import (render_params,
                        METADATA_FILE, MIPMAP_TILESPECS_JSON, scratch_dir)
 import os
 
@@ -69,6 +69,16 @@ def validate_mipmap_generated(in_ts,out_ts,levels,imgformat='tif'):
         assert w == expected_width // (2 ** lvl)
         assert h == expected_height // (2 ** lvl)
 
+
+def outfile_test_and_remove(f, output_fn):
+    assert not os.path.isfile(output_fn)
+    val = f()
+    assert os.path.isfile(output_fn)
+    assert os.remove(output_fn)
+    assert not os.path.isfile(output_fn)
+    return val
+
+
 def apply_generated_mipmaps(r, output_stack, generate_params):
     ex = apply_mipmaps_to_render.example
     ex['render'] = r.make_kwargs()
@@ -83,9 +93,12 @@ def apply_generated_mipmaps(r, output_stack, generate_params):
         in renderapi.tilespec.get_tile_specs_from_stack(
             ex['input_stack'], render=r)}
 
-    mod = apply_mipmaps_to_render.AddMipMapsToStack(input_data=ex, args=[])
+    outfn = 'TEST_applymipmapsoutput.json'
+    mod = apply_mipmaps_to_render.AddMipMapsToStack(
+        input_data=ex, args=['--output_json', outfn])
     mod.logger.setLevel(logging.DEBUG)
-    mod.run()
+
+    outfile_test_and_remove(mod.run, outfn)
 
     out_tileIdtotspecs = {
         ts.tileId: ts for ts
@@ -100,7 +113,7 @@ def apply_generated_mipmaps(r, output_stack, generate_params):
 
 @pytest.fixture(scope='module')
 def tspecs_to_mipmap():
-    tilespecs = [renderapi.tilespec.TileSpec(json=d) 
+    tilespecs = [renderapi.tilespec.TileSpec(json=d)
         for d in MIPMAP_TILESPECS_JSON]
     return tilespecs
 
@@ -121,6 +134,7 @@ def input_stack(render,tspecs_to_mipmap):
     yield test_input_stack
     renderapi.stack.delete_stack(test_input_stack, render=render)
 
+
 def addMipMapsToRender_test(render,output_stack,generate_params):
     tmpdir=tempfile.mkdtemp()
     input_stack = generate_params['input_stack']
@@ -129,7 +143,7 @@ def addMipMapsToRender_test(render,output_stack,generate_params):
     zvalues = renderapi.stack.get_z_values_for_stack(input_stack,render=render)
     z = zvalues[0]
 
-    ts_paths=apply_mipmaps_to_render.addMipMapsToRender(render, 
+    ts_paths=apply_mipmaps_to_render.addMipMapsToRender(render,
                                                         input_stack,
                                                         tmpdir,
                                                         imgformat,
@@ -161,8 +175,11 @@ def test_mipmaps(render, input_stack, tspecs_to_mipmap, output_stack=None):
     ex['zend'] = max([ts.z for ts in tspecs_to_mipmap])
     ex['output_dir'] = scratch_dir
 
-    mod = generate_mipmaps.GenerateMipMaps(input_data=ex, args=[])
-    mod.run()
+    outfn = 'TEST_genmipmaps.json'
+    mod = generate_mipmaps.GenerateMipMaps(
+        input_data=ex, args=['--output_json', outfn])
+
+    outfile_test_and_remove(mod.run, outfn)
 
     apply_generated_mipmaps(render, output_stack, ex)
     addMipMapsToRender_test(render, output_stack, ex)

--- a/rendermodules/dataimport/apply_mipmaps_to_render.py
+++ b/rendermodules/dataimport/apply_mipmaps_to_render.py
@@ -65,6 +65,7 @@ def addMipMapsToRender(render, input_stack, mipmap_dir, imgformat, levels, z):
 
 class AddMipMapsToStack(RenderModule):
     default_schema = AddMipMapsToStackParameters
+    default_output_schema = AddMipMapsToStackOutput
 
     def run(self):
         self.logger.debug('Applying mipmaps to stack')

--- a/rendermodules/dataimport/apply_mipmaps_to_render.py
+++ b/rendermodules/dataimport/apply_mipmaps_to_render.py
@@ -5,7 +5,8 @@ from ..module.render_module import RenderModule
 from functools import partial
 import urllib
 import urlparse
-from rendermodules.dataimport.schemas import AddMipMapsToStackParameters
+from rendermodules.dataimport.schemas import (
+    AddMipMapsToStackParameters, AddMipMapsToStackOutput)
 
 if __name__ == "__main__" and __package__ is None:
     __package__ = "rendermodules.dataimport.apply_mipmaps_to_render"

--- a/rendermodules/dataimport/apply_mipmaps_to_render.py
+++ b/rendermodules/dataimport/apply_mipmaps_to_render.py
@@ -30,12 +30,11 @@ example = {
 
 
 def addMipMapsToRender(render, input_stack, mipmap_dir, imgformat, levels, z):
-    tilespecPaths = []
+    # tilespecPaths = []
 
     tilespecs = render.run(renderapi.tilespec.get_tile_specs_from_z,
                            input_stack, z)
 
-    print z
     for ts in tilespecs:
         mm1 = ts.ip.mipMapLevels[0]
 
@@ -96,7 +95,6 @@ class AddMipMapsToStack(RenderModule):
             addMipMapsToRender, self.render, self.args['input_stack'],
             self.args['mipmap_dir'], self.args['imgformat'],
             self.args['levels'])
-
 
         with renderapi.client.WithPool(self.args['pool_size']) as pool:
             tilespecs = [i for l in pool.map(mypartial, zvalues)

--- a/rendermodules/dataimport/apply_mipmaps_to_render.py
+++ b/rendermodules/dataimport/apply_mipmaps_to_render.py
@@ -58,11 +58,9 @@ def addMipMapsToRender(render, input_stack, mipmap_dir, imgformat, levels, z):
             print scUrl
             mm1 = renderapi.tilespec.MipMapLevel(level=i, imageUrl=scUrl)
             ts.ip.update(mm1)
-
-    tilespecPaths.append(renderapi.utils.renderdump_temp(tilespecs))
-    return tilespecPaths
-
-
+    return tilespecs
+    # tilespecPaths.append(renderapi.utils.renderdump_temp(tilespecs))
+    # return tilespecPaths
 
 
 class AddMipMapsToStack(RenderModule):
@@ -97,9 +95,14 @@ class AddMipMapsToStack(RenderModule):
             self.args['mipmap_dir'], self.args['imgformat'],
             self.args['levels'])
 
+
         with renderapi.client.WithPool(self.args['pool_size']) as pool:
-            tilespecPaths = [i for l in pool.map(mypartial, zvalues)
-                             for i in l]
+            tilespecs = [i for l in pool.map(mypartial, zvalues)
+                         for i in l]
+
+        # with renderapi.client.WithPool(self.args['pool_size']) as pool:
+        #     tilespecPaths = [i for l in pool.map(mypartial, zvalues)
+        #                      for i in l]
 
         # add the tile spec to render stack
         try:
@@ -119,9 +122,13 @@ class AddMipMapsToStack(RenderModule):
 
         self.render.run(renderapi.stack.set_stack_state,
                         output_stack, 'LOADING')
-        self.render.run(renderapi.client.import_jsonfiles_parallel,
-                        output_stack, tilespecPaths,
-                        close_stack=self.args['close_stack'])
+        self.render.run(renderapi.client.import_tilespecs_parallel,
+                        output_stack, tilespecs,
+                        poolsize=self.args['pool_size'], close_stack=False)
+        # self.render.run(renderapi.client.import_jsonfiles_parallel,
+        #                 output_stack, tilespecPaths,
+        #                 close_stack=self.args['close_stack'])
+        self.output({"output_stack": output_stack})
 
 
 if __name__ == "__main__":

--- a/rendermodules/dataimport/create_mipmaps.py
+++ b/rendermodules/dataimport/create_mipmaps.py
@@ -1,10 +1,12 @@
-from PIL import Image
-import argparse
 import os
+from PIL import Image
 from rendermodules.module.render_module import RenderModuleException
+
 
 class CreateMipMapException(RenderModuleException):
     """Exception raised when there is a problem creating a mipmap"""
+    pass
+
 
 def create_mipmaps(inputImage, outputDirectory='.', mipmaplevels=[1, 2, 3],
                    outputformat='tif', convertTo8bit=True, force_redo=True):
@@ -24,12 +26,12 @@ def create_mipmaps(inputImage, outputDirectory='.', mipmaplevels=[1, 2, 3],
         whether to convert the image to 8 bit, dividing each value by 255
     force_redo: boolean
         whether to recreate mip map images if they already exist
-    
+
     Returns
     =======
     list
         list of output images created in order of levels
-    
+
     Raises
     ======
     MipMapException
@@ -59,7 +61,7 @@ def create_mipmaps(inputImage, outputDirectory='.', mipmaplevels=[1, 2, 3],
                                '{basename}.{fmt}'.format(
                                    basename=inputImage.lstrip(os.sep),
                                    fmt=outputformat))
-        makeImage=True
+        makeImage = True
         if os.path.isfile(outpath):
             if not force_redo:
                 makeImage = False

--- a/rendermodules/dataimport/generate_mipmaps.py
+++ b/rendermodules/dataimport/generate_mipmaps.py
@@ -63,7 +63,8 @@ def make_tilespecs_and_cmds(render, inputStack, output_dir, zvalues, levels,
 
     mypartial = partial(
         create_mipmap_from_tuple, levels=range(1, levels + 1),
-        convertTo8bit=convert_to_8bit, force_redo=force_redo, imgformat=imgformat)
+        convertTo8bit=convert_to_8bit, force_redo=force_redo,
+        imgformat=imgformat)
 
     with renderapi.client.WithPool(pool_size) as pool:
         results = pool.map(mypartial, mipmap_args)

--- a/rendermodules/dataimport/generate_mipmaps.py
+++ b/rendermodules/dataimport/generate_mipmaps.py
@@ -119,8 +119,7 @@ class GenerateMipMaps(RenderModule):
                                                   self.args['convert_to_8bit'],
                                                   self.args['force_redo'],
                                                   self.args['pool_size'])
-        self.output({"levels": self.args["levels"],
-                     "output_dir": self.args["output_dir"]})
+
         else:
             raise RenderModuleException(
                 "method {} not supported".format(self.args['method']))
@@ -128,6 +127,8 @@ class GenerateMipMaps(RenderModule):
             # missing_files = verify_mipmap_generation(mipmap_args)
             # if not missing_files:
             #     self.logger.error("not all mipmaps have been generated")
+        self.output({"levels": self.args["levels"],
+                     "output_dir": self.args["output_dir"]})
 
 
 if __name__ == "__main__":

--- a/rendermodules/dataimport/generate_mipmaps.py
+++ b/rendermodules/dataimport/generate_mipmaps.py
@@ -83,6 +83,7 @@ def verify_mipmap_generation(mipmap_args):
 
 class GenerateMipMaps(RenderModule):
     default_schema = GenerateMipMapsParameters
+    default_output_schema = GenerateMipMapsOutput
 
     def run(self):
         self.logger.debug('Mipmap generation module')

--- a/rendermodules/dataimport/generate_mipmaps.py
+++ b/rendermodules/dataimport/generate_mipmaps.py
@@ -3,7 +3,7 @@ import urllib
 import urlparse
 from rendermodules.dataimport.create_mipmaps import create_mipmaps
 from functools import partial
-from ..module.render_module import RenderModule, RenderParameters, RenderModuleException
+from ..module.render_module import RenderModule, RenderModuleException
 from rendermodules.dataimport.schemas import GenerateMipMapsParameters
 
 if __name__ == "__main__" and __package__ is None:
@@ -118,6 +118,8 @@ class GenerateMipMaps(RenderModule):
                                                   self.args['convert_to_8bit'],
                                                   self.args['force_redo'],
                                                   self.args['pool_size'])
+        self.output({"levels": self.args["levels"],
+                     "output_dir": self.args["output_dir"]})
         else:
             raise RenderModuleException(
                 "method {} not supported".format(self.args['method']))

--- a/rendermodules/dataimport/generate_mipmaps.py
+++ b/rendermodules/dataimport/generate_mipmaps.py
@@ -4,7 +4,8 @@ import urlparse
 from rendermodules.dataimport.create_mipmaps import create_mipmaps
 from functools import partial
 from ..module.render_module import RenderModule, RenderModuleException
-from rendermodules.dataimport.schemas import GenerateMipMapsParameters
+from rendermodules.dataimport.schemas import (
+    GenerateMipMapsParameters, GenerateMipMapsOutput)
 
 if __name__ == "__main__" and __package__ is None:
     __package__ = "rendermodules.dataimport.generate_mipmaps"

--- a/rendermodules/dataimport/schemas.py
+++ b/rendermodules/dataimport/schemas.py
@@ -1,8 +1,14 @@
 import marshmallow as mm
-from argschema.fields import InputDir,InputFile, Str, Int, Boolean, InputDir
+from argschema.fields import InputDir, InputFile, Str, Int, Boolean, InputDir
 from ..module.schemas import RenderParameters
 from marshmallow import ValidationError, validates_schema, post_load
 from argschema.schemas import DefaultSchema
+
+
+class GenerateMipMapsOutput(DefaultSchema):
+    levels = Int(required=True)
+    output_dir = Str(required=True)
+
 
 class GenerateMipMapsParameters(RenderParameters):
     input_stack = mm.fields.Str(
@@ -63,6 +69,11 @@ class GenerateMipMapsParameters(RenderParameters):
         }
         exc_fields = excluded_fields[options['method']]
         return cls(exclude=exc_fields).dump(options)
+
+
+class AddMipMapsToStackOutput(DefaultSchema):
+    output_stack = Str(required=True)
+
 
 class AddMipMapsToStackParameters(RenderParameters):
     input_stack = mm.fields.Str(

--- a/rendermodules/dataimport/schemas.py
+++ b/rendermodules/dataimport/schemas.py
@@ -1,7 +1,7 @@
 import marshmallow as mm
 from argschema.fields import InputDir, InputFile, Str, Int, Boolean, InputDir
 from ..module.schemas import RenderParameters
-from marshmallow import ValidationError, validates_schema, post_load
+from marshmallow import ValidationError, post_load
 from argschema.schemas import DefaultSchema
 
 
@@ -154,6 +154,7 @@ class GenerateEMTileSpecsParameters(RenderParameters):
         description=("sectionId to apply to tiles during ingest.  "
                      "If unspecified will default to a string "
                      "representation of the float value of z_index."))
+
 
 class GenerateEMTileSpecsOutput(DefaultSchema):
     stack = Str(required=True,


### PR DESCRIPTION
Adds output schemas for mipmaps and uses tilespec-based parallelization for applymipmaps.  These versions were cherry picked from repo used for EM December SMART goal.