### PR TITLE
Montage stack

### DIFF
--- a/integration_tests/test_em_montage.py
+++ b/integration_tests/test_em_montage.py
@@ -143,19 +143,3 @@ def test_fail_montage_job_for_section(render,
     with pytest.raises(RenderModuleException):
         mod = SolveMontageSectionModule(input_data=solver_example, args=[])
         mod.run()
-
-def test_fail_montage_job_output(render,
-                                     raw_stack,
-                                     test_point_match_generation,
-                                     tmpdir_factory,
-                                     output_stack=None):
-    if output_stack is None:
-        output_stack = '{}_Montage'.format(raw_stack)
-    output_directory = str(tmpdir_factory.mktemp('output_json'))
-    solver_example['source_collection']['stack'] = raw_stack
-    solver_example['target_collection']['stack'] = output_stack
-    solver_example['source_point_match_collection']['match_collection'] = test_point_match_generation
-    solver_example['z_value'] = montage_z
-    with pytest.raises(RenderModuleException):
-        mod = SolveMontageSectionModule(input_data=solver_example, args=[])
-        mod.run()

--- a/integration_tests/test_em_montage.py
+++ b/integration_tests/test_em_montage.py
@@ -16,7 +16,7 @@ from test_data import (RAW_STACK_INPUT_JSON,
 from rendermodules.montage.run_montage_job_for_section import  SolveMontageSectionModule
 from rendermodules.pointmatch.create_tilepairs import TilePairClientModule
 from rendermodules.pointmatch.generate_point_matches_spark import PointMatchClientModuleSpark
-
+from rendermodules.module.render_module import RenderModuleException
 logger = renderapi.client.logger
 logger.setLevel(logging.DEBUG)
 
@@ -126,3 +126,36 @@ def test_run_montage_job_for_section(render,
     # check the number of tiles in the montage
     tilespecs = renderapi.tilespec.get_tile_specs_from_z(output_stack, solver_example['z_value'], render=render)
     assert len(tilespecs) == 4
+
+def test_fail_montage_job_for_section(render,
+                                     raw_stack,
+                                     test_point_match_generation,
+                                     tmpdir_factory,
+                                     output_stack=None):
+    if output_stack is None:
+        output_stack = '{}_Montage'.format(raw_stack)
+    output_directory = str(tmpdir_factory.mktemp('output_json'))
+    solver_example['output_json']=os.path.join(output_directory,'output.json')
+    solver_example['source_collection']['stack'] = raw_stack
+    solver_example['target_collection']['stack'] = output_stack
+    solver_example['source_point_match_collection']['match_collection'] = 'notacollection'
+    solver_example['z_value'] = montage_z
+    with pytest.raises(RenderModuleException):
+        mod = SolveMontageSectionModule(input_data=solver_example, args=[])
+        mod.run()
+
+def test_fail_montage_job_output(render,
+                                     raw_stack,
+                                     test_point_match_generation,
+                                     tmpdir_factory,
+                                     output_stack=None):
+    if output_stack is None:
+        output_stack = '{}_Montage'.format(raw_stack)
+    output_directory = str(tmpdir_factory.mktemp('output_json'))
+    solver_example['source_collection']['stack'] = raw_stack
+    solver_example['target_collection']['stack'] = output_stack
+    solver_example['source_point_match_collection']['match_collection'] = test_point_match_generation
+    solver_example['z_value'] = montage_z
+    with pytest.raises(RenderModuleException):
+        mod = SolveMontageSectionModule(input_data=solver_example, args=[])
+        mod.run()

--- a/integration_tests/test_files/run_montage_job_for_section_template.json
+++ b/integration_tests/test_files/run_montage_job_for_section_template.json
@@ -49,25 +49,13 @@
   	},
     "source_collection": {
   		"stack": "mm2_acquire_8bit",
-  		"owner": "{{render_owner}}",
-  		"project": "{{render_project}}",
-  		"service_host": "{{render_host}}:{{render_port}}",
-  		"baseURL": "http://{{render_host}}:{{render_port}}/render-ws/v1",
-  		"renderbinPath": "{{render_client_scripts}}",
   		"verbose": 0
   	},
     "target_collection": {
   		"stack": "mm2_acquire_8bit_Montage",
-      "owner": "{{render_owner}}",
-  		"project": "{{render_project}}",
-  		"service_host": "{{render_host}}:{{render_port}}",
-  		"baseURL": "http://{{render_host}}:{{render_port}}/render-ws/v1",
-      "renderbinPath": "{{render_client_scripts}}",
       "verbose": 0
   	},
     "source_point_match_collection": {
-  		"server": "http://{{render_host}}:{{render_port}}/render-ws/v1",
-  		"owner": "{{render_owner}}",
   		"match_collection": "{{point_match_collection}}",
       "verbose": 0
   	},

--- a/rendermodules/montage/run_montage_job_for_section.py
+++ b/rendermodules/montage/run_montage_job_for_section.py
@@ -104,8 +104,9 @@ class SolveMontageSectionModule(RenderModule):
         self.args.pop('solver_executable', None)
         self.clone_section_stack = self.args['clone_section_stack']
         self.args.pop('clone_section_stack')
-        if (self.args['first_section']!=self.args['last_section']):
-            raise ValidationError("first section and last section not equal")
+        if self.clone_section_stack:
+            if (self.args['first_section']!=self.args['last_section']):
+                raise ValidationError("first section and last section not equal")
 
     def run(self):
 
@@ -146,7 +147,7 @@ class SolveMontageSectionModule(RenderModule):
         if self.args.get('output_json',None) is not None:
             sectionDataList = renderapi.stack.get_stack_sectionData(self.args['target_collection']['stack'],
                 render=self.render)
-            sectionData = next(section for section in sectionDataList if section['z']==self.args['first_section'])
+            sectionData = [section for section in sectionDataList if (section['z']>=self.args['first_section']) and (section['z'<=self.args['last_section'])]
             self.output(sectionData)
         
         #if you made a tmp stack destroy it

--- a/rendermodules/montage/run_montage_job_for_section.py
+++ b/rendermodules/montage/run_montage_job_for_section.py
@@ -153,7 +153,7 @@ class SolveMontageSectionModule(RenderModule):
             d={'zs':zs}
             self.output(d)
         except:
-            pass
+            raise RenderModuleException("unable to output json {}",d)
         
         #if you made a tmp stack destroy it
         if self.clone_section_stack:

--- a/rendermodules/montage/run_montage_job_for_section.py
+++ b/rendermodules/montage/run_montage_job_for_section.py
@@ -147,7 +147,9 @@ class SolveMontageSectionModule(RenderModule):
         if self.args.get('output_json',None) is not None:
             sectionDataList = renderapi.stack.get_stack_sectionData(self.args['target_collection']['stack'],
                 render=self.render)
-            sectionData = [section for section in sectionDataList if (section['z']>=self.args['first_section']) and (section['z'<=self.args['last_section'])]
+            sectionData = [section for section in sectionDataList \
+                if (section['z']>=self.args['first_section']) \
+                and (section['z']<=self.args['last_section'])]
             self.output(sectionData)
         
         #if you made a tmp stack destroy it

--- a/rendermodules/montage/run_montage_job_for_section.py
+++ b/rendermodules/montage/run_montage_job_for_section.py
@@ -118,7 +118,7 @@ class SolveMontageSectionModule(RenderModule):
                                            time.strftime("%m%d%y_%H%M%S"))
             zvalues = renderapi.stack.get_z_values_for_stack(self.args['source_collection']['stack'],render=self.render)
             zs = [z for z in zvalues if \
-                if (z>=self.args['first_section']) \
+                (z>=self.args['first_section']) \
                 and (z<=self.args['last_section'])]]
             renderapi.stack.clone_stack(self.args['source_collection']['stack'],
                                         tmp_stack,

--- a/rendermodules/montage/run_montage_job_for_section.py
+++ b/rendermodules/montage/run_montage_job_for_section.py
@@ -119,7 +119,7 @@ class SolveMontageSectionModule(RenderModule):
             zvalues = renderapi.stack.get_z_values_for_stack(self.args['source_collection']['stack'],render=self.render)
             zs = [z for z in zvalues if \
                 (z>=self.args['first_section']) \
-                and (z<=self.args['last_section'])]]
+                and (z<=self.args['last_section'])]
             renderapi.stack.clone_stack(self.args['source_collection']['stack'],
                                         tmp_stack,
                                         zs=zs,

--- a/rendermodules/montage/run_montage_job_for_section.py
+++ b/rendermodules/montage/run_montage_job_for_section.py
@@ -91,71 +91,6 @@ example = {
     "solver_executable": "/allen/aibs/pipeline/image_processing/volume_assembly/EMAligner/dev/allen_templates/run_em_solver.sh"
 }
 
-'''
-example = {
-    "render": {
-        "host": "http://em-131fs",
-        "port": 8998,
-        "owner": "gayathri",
-        "project": "MM2",
-        "client_scripts": "/allen/programs/celltypes/workgroups/em-connectomics/gayathrim/nc-em2/Janelia_Pipeline/render_20170613/render-ws-java-client/src/main/scripts"
-    },
-    "solver_options": {
-		"min_tiles": 3,
-		"degree": 1,
-		"outlier_lambda": 1000,
-		"solver": "backslash",
-		"min_points": 4,
-		"max_points": 80,
-		"stvec_flag": 0,
-		"conn_comp": 1,
-		"distributed": 0,
-		"lambda_value": 1,
-		"edge_lambda": 0.1,
-		"small_region_lambda": 10,
-		"small_region": 5,
-		"calc_confidence": 1,
-		"translation_fac": 1,
-		"use_peg": 1,
-		"peg_weight": 0.0001,
-		"peg_npoints": 5
-	},
-    "source_collection": {
-		"stack": "mm2_acquire_8bit",
-		"owner": "gayathri",
-		"project": "MM2",
-		"service_host": "em-131fs:8998",
-		"baseURL": "http://em-131fs:8998/render-ws/v1",
-		"renderbinPath": "/allen/programs/celltypes/workgroups/em-connectomics/gayathrim/nc-em2/Janelia_Pipeline/render_20170613/render-ws-java-client/src/main/scripts",
-		"verbose": 0
-	},
-    "target_collection": {
-		"stack": "mm2_acquire_8bit_Montage",
-        "owner": "gayathri",
-		"project": "MM2",
-		"service_host": "em-131fs:8998",
-		"baseURL": "http://em-131fs:8998/render-ws/v1",
-		"renderbinPath": "/allen/programs/celltypes/workgroups/em-connectomics/gayathrim/nc-em2/Janelia_Pipeline/render_20170613/render-ws-java-client/src/main/scripts",
-		"verbose": 0,
-		"initialize": 0,
-		"complete": 1
-	},
-    "source_point_match_collection": {
-		"server": "http://em-131fs:8998/render-ws/v1",
-		"owner": "gayathri_MM2",
-		"match_collection": "mm2_acquire_8bit_montage"
-	},
-    "z_value": 1049,
-	"filter_point_matches": 1,
-    "solver_executable": "/allen/programs/celltypes/workgroups/em-connectomics/gayathrim/nc-em2/Janelia_Pipeline/EM_aligner/matlab_compiled/solve_montage_SL",
-	"temp_dir": "/allen/programs/celltypes/workgroups/em-connectomics/gayathrim/nc-em2/Janelia_Pipeline/scratch",
-	"dir_scratch": "/allen/programs/celltypes/workgroups/em-connectomics/gayathrim/nc-em2/Janelia_Pipeline/scratch",
-	"renderer_client": "/data/nc-em2/gayathrim/renderBin/bin/render.sh",
-	"disableValidation": 1,
-	"verbose": 0
-}
-'''
-
 class SolveMontageSectionModule(RenderModule):
     def __init__(self, schema_type=None, *args, **kwargs):
         if schema_type is None:
@@ -167,8 +102,22 @@ class SolveMontageSectionModule(RenderModule):
         # Assigning the solver_executable to a different variable and removing it from args
         self.solver_executable = self.args['solver_executable']
         self.args.pop('solver_executable', None)
+        self.clone_section_stack = self.args['clone_section_stack']
+        self.args.pop('clone_section_stack')
+        if (self.args['first_section']!=self.args['last_section']):
+            raise ValidationError("first section and last section not equal")
 
     def run(self):
+
+        if self.clone_section_stack:
+            tmp_stack = "{}_z{}".format(self.args['source_collection']['stack'],self.args['first_section'])
+            renderapi.stack.clone_stack(self.args['source_collection']['stack'],
+                                        tmp_stack,
+                                        zs=[self.args['first_section']],
+                                        close_stack=True,
+                                        render=self.render)
+            self.args['source_collection']['stack']=tmp_stack
+
         # generate a temporary json to feed in to the solver
         tempjson = tempfile.NamedTemporaryFile(
             suffix=".json",
@@ -180,32 +129,10 @@ class SolveMontageSectionModule(RenderModule):
             json.dump(self.args, f, indent=4)
             f.close()
 
-        # create the command to run
-        # this code assumes that matlab environment is setup in the server for the user
-        # add this to your profile
-        # Note that MCRROOT is the matlab compiler runtime's root folder
-        '''
-            LD_LIBRARY_PATH=.:${MCRROOT}/runtime/glnxa64 ;
-            LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${MCRROOT}/bin/glnxa64 ;
-            LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${MCRROOT}/sys/os/glnxa64;
-            LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${MCRROOT}/sys/opengl/lib/glnxa64;
-        '''
-
         if "MCRROOT" not in os.environ:
             raise ValidationError("MCRROOT not set")
         
-        # os.environ['LD_LIBRARY_PATH']=''
-        # mcrroot = os.environ['MCRROOT']
-        # path1 = os.path.join(mcrroot, 'runtime/glnxa64')
-        # path2 = os.path.join(mcrroot, 'bin/glnxa64')
-        # path3 = os.path.join(mcrroot, 'sys/os/glnxa64')
-        # path4 = os.path.join(mcrroot, 'sys/opengl/lib/glnxa64')
-        
-        # os.environ['LD_LIBRARY_PATH'] += path1 + os.pathsep
-        # os.environ['LD_LIBRARY_PATH'] += path2 + os.pathsep
-        # os.environ['LD_LIBRARY_PATH'] += path3 + os.pathsep
-        # os.environ['LD_LIBRARY_PATH'] += path4 + os.pathsep
-                
+        #assumes that solver_executable is the shell script that sets the LD_LIBRARY path and calls the executable
         cmd = "%s %s %s"%(self.solver_executable, os.environ['MCRROOT'],tempjson.name)
         ret = os.system(cmd)
 
@@ -215,36 +142,17 @@ class SolveMontageSectionModule(RenderModule):
         else:
             raise RenderModuleException("solve failed with input_json {}",self.args)
 
-        sectionDataList = renderapi.stack.get_stack_sectionData(self.args['target_collection']['stack'],
-            render=self.render)
-        sectionData = next(section for section in sectionDataList if section['z']==self.args['first_section'])
-        self.output(sectionData)
-
-        '''
-        if os.path.isfile(self.solver_executable) and os.access(self.solver_executable, os.X_OK):
-            cmd_to_qsub = "%s %s"%(self.solver_executable, tempjson.name)
-
-            #generate pbs file
-            temppbs = tempfile.NamedTemporaryFile(
-                suffix=".pbs",
-                mode="w",
-                delete=False)
-            temppbs.close()
-
-            with open(temppbs.name, 'w') as f:
-                f.write('#PBS -l mem=60g\n')
-                f.write('#PBS -l walltime=00:30:00\n')
-                f.write('#PBS -l ncpus=1\n')
-                f.write('#PBS -N Montage\n')
-                f.write('#PBS -r n\n')
-                f.write('#PBS -m n\n')
-                f.write('#PBS -q emconnectome\n')
-                f.write('%s\n'%(cmd_to_qsub))
-            f.close()
-
-            qsub_cmd = 'qsub %s'%(temppbs.name)
-            subprocess.call(qsub_cmd)
-        '''
+        #return the section data as the output_json if it was given
+        if self.args.get('output_json',None) is not None:
+            sectionDataList = renderapi.stack.get_stack_sectionData(self.args['target_collection']['stack'],
+                render=self.render)
+            sectionData = next(section for section in sectionDataList if section['z']==self.args['first_section'])
+            self.output(sectionData)
+        
+        #if you made a tmp stack destroy it
+        if self.clone_section_stack:
+            renderapi.stack.delete_stack(tmp_stack,render=self.render)
+       
 
 if __name__ == "__main__":
     mod = SolveMontageSectionModule(input_data=example)

--- a/rendermodules/montage/run_montage_job_for_section.py
+++ b/rendermodules/montage/run_montage_job_for_section.py
@@ -149,9 +149,11 @@ class SolveMontageSectionModule(RenderModule):
             raise RenderModuleException("solve failed with input_json {}",self.args)
 
         #return the section data as the output_json if it was given
-        if self.args.get('output_json',None) is not None:
+        try:
             d={'zs':zs}
             self.output(d)
+        except:
+            pass
         
         #if you made a tmp stack destroy it
         if self.clone_section_stack:

--- a/rendermodules/montage/run_montage_job_for_section.py
+++ b/rendermodules/montage/run_montage_job_for_section.py
@@ -150,12 +150,8 @@ class SolveMontageSectionModule(RenderModule):
 
         #return the section data as the output_json if it was given
         if self.args.get('output_json',None) is not None:
-            sectionDataList = renderapi.stack.get_stack_sectionData(self.args['target_collection']['stack'],
-                render=self.render)
-            sectionData = [section for section in sectionDataList \
-                if (section['z']>=self.args['first_section']) \
-                and (section['z']<=self.args['last_section'])]
-            self.output(sectionData)
+            d={'zs':zs}
+            self.output(d)
         
         #if you made a tmp stack destroy it
         if self.clone_section_stack:

--- a/rendermodules/montage/run_montage_job_for_section.py
+++ b/rendermodules/montage/run_montage_job_for_section.py
@@ -148,7 +148,7 @@ class SolveMontageSectionModule(RenderModule):
         else:
             raise RenderModuleException("solve failed with input_json {}",self.args)
 
-        #return the section data as the output_json if it was given
+        #try to return the z's solved in the output json
         try:
             d={'zs':zs}
             self.output(d)

--- a/rendermodules/montage/run_montage_job_for_section.py
+++ b/rendermodules/montage/run_montage_job_for_section.py
@@ -112,7 +112,7 @@ class SolveMontageSectionModule(RenderModule):
         if "MCRROOT" not in os.environ:
             raise ValidationError("MCRROOT not set")
         if self.clone_section_stack:
-            tmp_stack = "{}_z{}-{}_{}".format(self.args['source_collection']['stack'],
+            tmp_stack = "{}_zs{}_ze{}_t{}".format(self.args['source_collection']['stack'],
                                            self.args['first_section'],
                                            self.args['last_section'],
                                            time.strftime("%m%d%y_%H%M%S"))

--- a/rendermodules/montage/schemas.py
+++ b/rendermodules/montage/schemas.py
@@ -339,41 +339,24 @@ class PointMatchCollectionParameters(DefaultSchema):
 
 
 class SolveMontageSectionParameters(RenderParameters):
-    #z_value = Int(
-    #    required=True,
-    #    description="Z value of section to be montaged")
     first_section = Int(
         required=True,
         description="Z index of the first section")
     last_section = Int(
         required=True,
         description="Z index of the last section")
-    #filter_point_matches = Int(
-    #    required=False,
-    #    default=1,
-    #    missing=1,
-    #    description="Do you want to filter point matches? default - 1")
+    clone_section_stack = Bool(
+        required=False,
+        default=True,
+        description="Whether to clone out a temporary single section stack from source_collection stack")
     solver_executable = Str(
         required=True,
         description="Matlab solver executable with full path")
-    #temp_dir = InputDir(
-    #    required=True,
-    #    default="/allen/aibs/shared/image_processing/volume_assembly/scratch",
-    #    description="Path to temporary directory")
     verbose = Int(
         required=False,
         default=0,
         missing=0,
         description="Verbose output from solver needed?")
-    #scratch = InputDir(
-    #    required=True,
-    #    default="/allen/aibs/shared/image_processing/volume_assembly/scratch",
-    #    description="Path to scratch directory - can be the same as temp_dir")
-    #renderer_client = Str(
-    #    required=False,
-    #    default=None,
-    #    missing=None,
-    #    description="Path to render client script render.sh")
     solver_options = Nested(
         SolverOptionsParameters,
         required=True,
@@ -381,7 +364,7 @@ class SolveMontageSectionParameters(RenderParameters):
     source_collection = Nested(
         SourceStackParameters,
         required=True,
-        description="Input stack parameters")
+        description="Input stack parameters, will be created and deleted after from input_stack")
     target_collection = Nested(
         TargetStackParameters,
         required=True,
@@ -396,9 +379,6 @@ class SolveMontageSectionParameters(RenderParameters):
         # cannot create "lambda" as a variable name in SolverParameters
         data['solver_options']['lambda'] = data['solver_options']['lambda_value']
         data['solver_options'].pop('lambda_value', None)
-
-        #if data['renderer_client'] is None:
-        #    data['renderer_client'] = os.path.join(data['render']['client_scripts'], 'render.sh')
 
         if data['source_collection']['owner'] is None:
             data['source_collection']['owner'] = data['render']['owner']

--- a/rendermodules/montage/schemas.py
+++ b/rendermodules/montage/schemas.py
@@ -62,6 +62,10 @@ class SolverOptionsParameters(DefaultSchema):
         default="backslash",
         missing="backslash",
         description="type of solver to solve the system (default - backslash)")
+    close_stack = Bool(
+        required=False,
+        default=False,
+        description="whether the solver should close the stack after uploading results")
     transfac = Int(
         required=False,
         default=1,

--- a/rendermodules/montage/schemas.py
+++ b/rendermodules/montage/schemas.py
@@ -391,7 +391,7 @@ class SolveMontageSectionParameters(RenderParameters):
         if data['source_collection']['service_host'] is None:
             data['source_collection']['service_host'] = data['render']['host'][7:] + ":" + str(data['render']['port'])
         if data['source_collection']['baseURL'] is None:
-            data['source_collection']['baseURL'] = data['render']['host'] + ":" + str(data['render']['port']) + '/render-ws/v1'
+            data['source_collection']['baseURL'] = "http://{}:{}/render-ws/v1".format(data['render']['host'],data['render']['port']) 
         if data['source_collection']['renderbinPath'] is None:
             data['source_collection']['renderbinPath'] = data['render']['client_scripts']
 
@@ -402,7 +402,7 @@ class SolveMontageSectionParameters(RenderParameters):
         if data['target_collection']['service_host'] is None:
             data['target_collection']['service_host'] = data['render']['host'][7:] + ":" + str(data['render']['port'])
         if data['target_collection']['baseURL'] is None:
-            data['target_collection']['baseURL'] = data['render']['host'] + ":" + str(data['render']['port']) + '/render-ws/v1'
+            data['target_collection']['baseURL'] = "http://{}:{}/render-ws/v1".format(data['render']['host'],data['render']['port']) 
         if data['target_collection']['renderbinPath'] is None:
             data['target_collection']['renderbinPath'] = data['render']['client_scripts']
 


### PR DESCRIPTION
This solves the problem of the injesting stack being in the loading stack by cloning the section to be montage solved into a temporary section only stack before solving and then deleting it after. It is transparent to the workflow engine. We can if we want explore in the future having it push the single section stack to another render engine to make there be no more net load on the render server (one read, one write, per section per solve).