### PR TITLE
Remove argschema module

### DIFF
--- a/integration_tests/test_render_module.py
+++ b/integration_tests/test_render_module.py
@@ -1,0 +1,17 @@
+from rendermodules.module.render_module import RenderModule, RenderModuleException
+from rendermodules.module.schemas import RenderParameters
+import argschema
+from test_data import render_params
+import pytest
+
+def test_render_modules():
+    d = {'render':render_params}
+    mod = RenderModule(input_data = d,args=[])
+    assert(mod.args['render']==render_params)
+
+class NotARenderSchema(argschema.ArgSchema):
+    pass
+
+def test_render_modules_fail():
+    with pytest.raises(RenderModuleException):
+        mod = RenderModule(input_data = {}, schema_type=NotARenderSchema, args=[])

--- a/rendermodules/lens_correction/lens_correction.py
+++ b/rendermodules/lens_correction/lens_correction.py
@@ -5,7 +5,7 @@ import tempfile
 import shutil
 from rendermodules.lens_correction.schemas import LensCorrectionOutput, LensCorrectionParameters
 from argschema import ArgSchemaParser
-from rendermodules.module.render_module import RenderModuleException, ArgSchemaModule
+from rendermodules.module.render_module import RenderModuleException
 
 example_input = {
     "manifest_path": "/allen/programs/celltypes/workgroups/em-connectomics/samk/lc_test_data/Wij_Set_594451332/594089217_594451332/_trackem_20170502174048_295434_5LC_0064_01_20170502174047_reference_0_.txt",

--- a/rendermodules/module/render_module.py
+++ b/rendermodules/module/render_module.py
@@ -6,14 +6,6 @@ class RenderModuleException(Exception):
     """Base Exception class for render module"""
     pass
 
-# this is deprecated and unnecessary now, leaving it in to minimize rewrite
-class ArgSchemaModule(argschema.ArgSchemaParser):
-    def __init__(self, *args, **kwargs):
-        super(ArgSchemaModule, self).__init__(
-            *args, **kwargs)
-        self.logger.warning("DEPRECATED: please just use \
-            argschema.ArgSchemaParser which has this functionality")
-
 class RenderModule(argschema.ArgSchemaParser):
     default_schema = RenderParameters
 


### PR DESCRIPTION
Looking through the code coverage i noted that this Deprecated module was not in fact getting used anywhere, so this PR removes it. 