### PR TITLE
Tilepair clean

### DIFF
--- a/integration_tests/test_em_montage.py
+++ b/integration_tests/test_em_montage.py
@@ -91,8 +91,8 @@ def test_create_montage_tile_pairs(render, raw_stack, tmpdir_factory):
     assert(len(npairs) == 4)
     yield tilepair_file
 
-def test_create_montage_tile_pairs_no_z(render, raw_stack, tmpdir_factory):
-    output_directory = str(tmpdir_factory.mktemp('Montage'))
+def test_create_montage_tile_pairs_no_z(render, raw_stack, tmpdir):
+    output_directory = str(tmpdir.join('Montage'))
     params = {
         "render": render_params,
         "zNeighborDistance": 0,
@@ -122,7 +122,6 @@ def test_create_montage_tile_pairs_no_z(render, raw_stack, tmpdir_factory):
         js = json.load(f)
     npairs = js['neighborPairs']
     assert(len(npairs) == 4)
-    yield tilepair_file
 
 
 @pytest.fixture(scope='module')

--- a/integration_tests/test_em_montage.py
+++ b/integration_tests/test_em_montage.py
@@ -76,12 +76,9 @@ def test_create_montage_tile_pairs(render, raw_stack, tmpdir_factory):
     mod.run()
 
     # check if the file has been created
-    tilepair_file = "tile_pairs_{}_z_{}_to_{}_dist_{}.json".format(
-                        raw_stack,
-                        params['minZ'],
-                        params['maxZ'],
-                        params['zNeighborDistance'])
-    tilepair_file = os.path.join(output_directory, tilepair_file)
+    with open(params['output_json'],'r') as fp:
+        out_d = json.load(fp)
+    tilepair_file = out_d['tile_pair_file']
 
     assert(os.path.exists(tilepair_file) and os.path.getsize(tilepair_file) > 0)
 
@@ -109,12 +106,9 @@ def test_create_montage_tile_pairs_no_z(render, raw_stack, tmpdir):
     mod.run()
 
     # check if the file has been created
-    tilepair_file = "tile_pairs_{}_z_{}_to_{}_dist_{}.json".format(
-                        raw_stack,
-                        params['minZ'],
-                        params['maxZ'],
-                        params['zNeighborDistance'])
-    tilepair_file = os.path.join(output_directory, tilepair_file)
+    with open(params['output_json'],'r') as fp:
+        out_d = json.load(fp)
+    tilepair_file = out_d['tile_pair_file']
 
     assert(os.path.exists(tilepair_file) and os.path.getsize(tilepair_file) > 0)
 

--- a/integration_tests/test_em_montage.py
+++ b/integration_tests/test_em_montage.py
@@ -88,8 +88,42 @@ def test_create_montage_tile_pairs(render, raw_stack, tmpdir_factory):
     with open(tilepair_file, 'r') as f:
         js = json.load(f)
     npairs = js['neighborPairs']
-    assert(len(npairs) > 0)
+    assert(len(npairs) == 4)
     yield tilepair_file
+
+def test_create_montage_tile_pairs_no_z(render, raw_stack, tmpdir_factory):
+    output_directory = str(tmpdir_factory.mktemp('Montage'))
+    params = {
+        "render": render_params,
+        "zNeighborDistance": 0,
+        "xyNeighborFactor": 0.9,
+        "excludeCornerNeighbors": "true",
+        "excludeSameLayerNeighbors": "false",
+        "excludeCompletelyObscuredTiles": "true",
+        "output_dir": output_directory,
+        "stack": raw_stack,
+        "output_json": "out.json"
+    }
+
+    mod = TilePairClientModule(input_data=params, args=[])
+    mod.run()
+
+    # check if the file has been created
+    tilepair_file = "tile_pairs_{}_z_{}_to_{}_dist_{}.json".format(
+                        raw_stack,
+                        params['minZ'],
+                        params['maxZ'],
+                        params['zNeighborDistance'])
+    tilepair_file = os.path.join(output_directory, tilepair_file)
+
+    assert(os.path.exists(tilepair_file) and os.path.getsize(tilepair_file) > 0)
+
+    with open(tilepair_file, 'r') as f:
+        js = json.load(f)
+    npairs = js['neighborPairs']
+    assert(len(npairs) == 4)
+    yield tilepair_file
+
 
 @pytest.fixture(scope='module')
 def test_point_match_generation(render, test_create_montage_tile_pairs,tmpdir_factory):

--- a/rendermodules/pointmatch/create_tilepairs.py
+++ b/rendermodules/pointmatch/create_tilepairs.py
@@ -38,33 +38,18 @@ class TilePairClientModule(RenderModule):
     client_class = 'org.janelia.render.client.TilePairClient'
     client_script_name = 'run_ws_client.sh'
 
-    @property
-    def default_client_script(self):
-        basecmd = os.path.join(
-                        self.args['render']['client_scripts'],
-                        self.client_script_name)
-        if not os.path.isfile(basecmd):
-            raise TilePairClientException(
-                'client script {} does not exist'.format(basecmd))
-        elif not os.access(basecmd, os.X_OK):
-            raise TilePairClientException(
-                'client script {} is not executable'.format(basecmd))
-        return basecmd
-
     def run(self):
-        basecmd = self.default_client_script
-
-        baseDataUrl = "%s:%d/render-ws/v1"%(self.args['render']['host'], self.args['render']['port'])
-
         zvalues = self.render.run(
             renderapi.stack.get_z_values_for_stack, self.args['stack'])
 
         if self.args['minZ'] is not None:
             self.args['minZ'] = self.args['minZ'] if self.args['minZ'] > min(zvalues) else min(zvalues)
-        elif self.args['maxZ'] is not None:
-            self.args['maxZ'] = self.args['maxZ'] if self.args['maxZ'] < max(zvalues) else max(zvalues)
         else:
             self.args['minZ'] = min(zvalues)
+            
+        if self.args['maxZ'] is not None:
+            self.args['maxZ'] = self.args['maxZ'] if self.args['maxZ'] < max(zvalues) else max(zvalues)
+        else: 
             self.args['maxZ'] = max(zvalues)
 
         tilepairJsonFile = "tile_pairs_%s_z_%d_to_%d_dist_%d.json"%(self.args['stack'], self.args['minZ'], self.args['maxZ'], self.args['zNeighborDistance'])
@@ -86,31 +71,7 @@ class TilePairClientModule(RenderModule):
                         excludeCompletelyObscuredTiles=self.args['excludeCompletelyObscuredTiles'])
 
         self.output({'tile_pair_file':tilepairJsonFile})
-        # non-render-python way of calling TilePairClient
-        '''
-        run_cmd = [
-                    basecmd,
-                    self.args['memGB'],
-                    self.client_class,
-                    "--baseDataUrl {}".format(baseDataUrl),
-                    "--owner {}".format(self.args['render']['owner']),
-                    "--project {}".format(self.args['render']['project']),
-                    "--baseOwner {}".format(self.args['render']['owner']),
-                    "--baseProject {}".format(self.args['render']['project']),
-                    "--baseStack {}".format(self.args['baseStack']),
-                    "--stack {}".format(self.args['stack']),
-                    "--minZ {}".format(self.args['minZ']),
-                    "--maxZ {}".format(self.args['maxZ']),
-                    "--xyNeighborFactor {}".format(self.args['xyNeighborFactor']),
-                    "--zNeighborDistance {}".format(self.args['zNeighborDistance']),
-                    "--excludeCornerNeighbors {}".format(self.args['excludeCornerNeighbors']),
-                    "--excludeSameLayerNeighbors {}".format(self.args['excludeSameLayerNeighbors']),
-                    "--excludeCompletelyObscuredTiles {}".format(self.args['excludeCompletelyObscuredTiles']),
-                    "--toJson {}".format(tilepairJsonFile)
-                    ]
-
-        subprocess.call(run_cmd)
-        '''
+        
 
 if __name__ == "__main__":
     module = TilePairClientModule(input_data=example)


### PR DESCRIPTION
In my quest to improve coverage i found more unused code in the tilepair module and what I think was a inconsequential bug in the logic surrounding z range setting.  I don't think setting in zranges to the tilepair client that are larger than the existing ranges really does anything bad, but the old code wasn't really don't something sensible.  I've also added tests that explicitly check that non-specifying a z works as well.