### PR TITLE
Rtreefix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Forrest Collman (forrest.collman@gmail.com)
 
 WORKDIR /shared/render-modules
 COPY . /shared/render-modules
-#RUN apt-get update && apt-get install -y libspatialindex-dev libxcomposite-dev && rm -rf /var/lib/apt/lists/*
-RUN conda install -c conda-forge rtree 
+RUN apt-get update && apt-get install -y libxcomposite-dev && rm -rf /var/lib/apt/lists/*
+RUN conda install -y -c conda-forge rtree 
 RUN python setup.py install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER Forrest Collman (forrest.collman@gmail.com)
 
 WORKDIR /shared/render-modules
 COPY . /shared/render-modules
-RUN apt-get update && apt-get install -y libspatialindex-dev libxcomposite-dev && rm -rf /var/lib/apt/lists/*
+#RUN apt-get update && apt-get install -y libspatialindex-dev libxcomposite-dev && rm -rf /var/lib/apt/lists/*
+RUN conda install -c conda-forge rtree 
 RUN python setup.py install
 


### PR DESCRIPTION
This changes the way that rtree is installed to do it through conda, which then installs the c dependancy lib-spatialindex which puts that under control of conda, so it is specified as part of the conda environment, which then makes deployment simplier. 