### PR TITLE
Overwrite z option

### DIFF
--- a/integration_tests/test_consolidate.py
+++ b/integration_tests/test_consolidate.py
@@ -46,9 +46,10 @@ def test_consolidate_module(render,test_stack):
         "pool_size": 2,
         "minZ":input_z[1],
         "maxZ":np.max(input_z),
-        "output_json":"test.json"
+        "output_json":"test.json",
+        "overwrite_zlayer": True
     }
-    
+
     mod = ConsolidateTransforms(input_data = params,args=[])
     mod.run()
 
@@ -57,12 +58,12 @@ def test_consolidate_module(render,test_stack):
     assert(len(output_z)==len(input_z)-1)
 
     #make sure the input_tilespecs are correct
-    input_tilespecs = renderapi.tilespec.get_tile_specs_from_stack(test_stack, render=render)   
+    input_tilespecs = renderapi.tilespec.get_tile_specs_from_stack(test_stack, render=render)
     # 2lens correction, 2 affines
     assert all([len(ts.tforms)==4 for ts in input_tilespecs])
 
     #make sure the output_tilespecs have the right number of transforms
-    output_tilespecs = renderapi.tilespec.get_tile_specs_from_stack(output_stack, render=render)   
+    output_tilespecs = renderapi.tilespec.get_tile_specs_from_stack(output_stack, render=render)
     #2 lens correction, 1 combined affine
     assert all([len(ts.tforms)==3 for ts in output_tilespecs])
 
@@ -82,7 +83,7 @@ def test_consolidate_single(render,test_stack,test_consolidate_module):
     input_z = np.array(renderapi.stack.get_z_values_for_stack(test_stack,render=render))
     print input_z,type(input_z)
     print len(input_z)
-    outputs=process_z(render, 
+    outputs=process_z(render,
               test_consolidate_module.logger,
               test_consolidate_module.args['stack'],
               test_consolidate_module.args['output_stack'],
@@ -94,7 +95,7 @@ def test_consolidate_transforms_function(render,test_stack):
 
     resolved_tiles = renderapi.resolvedtiles.get_resolved_tiles_from_z(
         test_stack, input_z[1], render=render)
-    
+
     tile0 = resolved_tiles.tilespecs[0]
     new_tforms=consolidate_transforms(tile0.tforms, resolved_tiles.transforms)
 
@@ -102,5 +103,3 @@ def test_consolidate_transforms_function(render,test_stack):
 
     with pytest.raises(RenderModuleException) as e:
         new_tforms=consolidate_transforms(tile0.tforms)
-        
-

--- a/integration_tests/test_dataimport.py
+++ b/integration_tests/test_dataimport.py
@@ -79,13 +79,14 @@ def outfile_test_and_remove(f, output_fn):
     os.remove(output_fn)
     assert not os.path.isfile(output_fn)
     return val
-       
+
 def apply_generated_mipmaps(r, output_stack, generate_params,z=None):
     ex = apply_mipmaps_to_render.example
     ex['render'] = r.make_kwargs()
     ex['input_stack'] = generate_params['input_stack']
     ex['output_stack'] = output_stack
     ex['mipmap_dir'] = generate_params['output_dir']
+    ex['overwrite_zlayer'] = True
     zvalues = renderapi.stack.get_z_values_for_stack(ex['input_stack'],render=r)
     if z is not None:
         ex['z']=z
@@ -193,7 +194,7 @@ def test_mipmaps(render, input_stack, tspecs_to_mipmap, output_stack=None):
 
     renderapi.stack.delete_stack(output_stack, render=render)
     addMipMapsToRender_test(render, ex)
-    
+
 
 def test_make_mipmaps_single_z(render, input_stack, tspecs_to_mipmap, tmpdir,output_stack=None):
     assert isinstance(render, renderapi.render.RenderClient)
@@ -222,7 +223,7 @@ def test_make_mipmaps_single_z(render, input_stack, tspecs_to_mipmap, tmpdir,out
         mod = generate_mipmaps.GenerateMipMaps(
             input_data=ex, args=['--output_json', outfn])
         mod.run()
-        
+
 def test_make_mipmaps_fail_no_z(render,input_stack,tmpdir):
     ex = generate_mipmaps.example
     ex['render'] = render.make_kwargs()

--- a/integration_tests/test_lens_correction.py
+++ b/integration_tests/test_lens_correction.py
@@ -141,7 +141,8 @@ def test_apply_lens_correction(render, stack_no_lc, stack_lc, example_tform_dict
         "zs": [2266],
         "transform": example_tform_dict,
         "refId": None,
-        "pool_size": 5
+        "pool_size": 5,
+        "overwrite_zlayer": True
     }
 
     mod = ApplyLensCorrection(input_data=params, args=['--output_json', 'test_ALC_out.json'])

--- a/integration_tests/test_multiplicative_correction.py
+++ b/integration_tests/test_multiplicative_correction.py
@@ -92,7 +92,8 @@ def test_apply_correction(test_median_stack, mini_raw_stack, render, tmpdir_fact
         "output_stack": output_stack,
         "output_directory": output_directory,
         "z_index": 0,
-        "pool_size": 10
+        "pool_size": 10,
+        "overwrite_zlayer": True
     }
     mod = MultIntensityCorr(input_data=params, args=[])
     mod.run()
@@ -121,7 +122,7 @@ def test_single_tile(test_apply_correction,render,tmpdir):
     N, M, C = getImage(corr_tilespecs[0])
 
 	#process_tile(C, dirout, stackname, clip,scale_factor,clip_min,clip_max,input_ts)
-    process_tile(C, 
+    process_tile(C,
                  test_apply_correction.args['output_directory'],
                  test_apply_correction.args['output_stack'],
 		 True, 1.0,0,65535,

--- a/rendermodules/dataimport/apply_mipmaps_to_render.py
+++ b/rendermodules/dataimport/apply_mipmaps_to_render.py
@@ -110,6 +110,16 @@ class AddMipMapsToStack(RenderModule):
 
         self.render.run(renderapi.stack.set_stack_state,
                         output_stack, 'LOADING')
+
+        if self.args['overwrite_zlayer']:
+            for z in zvalues:
+                try:
+                    renderapi.stack.delete_section(
+                        output_stack, z,
+                        render=self.render)
+                except renderapi.errors.RenderError as e:
+                    self.logger.error(e)
+
         self.render.run(renderapi.client.import_tilespecs_parallel,
                         output_stack, tilespecs,
                         poolsize=self.args['pool_size'], close_stack=False)

--- a/rendermodules/dataimport/schemas.py
+++ b/rendermodules/dataimport/schemas.py
@@ -77,7 +77,7 @@ class AddMipMapsToStackParameters(RenderParameters):
         required=True,
         description='stack for which the mipmaps are to be generated')
     output_stack = mm.fields.Str(
-        required=True, 
+        required=True,
         description='the output stack name. Leave to overwrite input stack')
     mipmap_dir = InputDir(
         required=True,
@@ -104,6 +104,10 @@ class AddMipMapsToStackParameters(RenderParameters):
         required=False, default=False,
         description=("whether to set output stack state to "
                      "'COMPLETE' upon completion"))
+    overwrite_zlayer = Boolean(
+        required=False, default=False,
+        description=("whether to remove the existing layer from the "
+                     "target stack before uploading."))
 
     @post_load
     def validate_zvalues(self, data):
@@ -154,4 +158,3 @@ class GenerateEMTileSpecsParameters(RenderParameters):
 class GenerateEMTileSpecsOutput(DefaultSchema):
     stack = Str(required=True,
                 description="stack to which generated tiles were added")
-

--- a/rendermodules/intensity_correction/apply_multiplicative_correction.py
+++ b/rendermodules/intensity_correction/apply_multiplicative_correction.py
@@ -29,7 +29,7 @@ example_input = {
 
 def intensity_corr(img, ff,clip,scale_factor,clip_min,clip_max):
     """utility function to correct an image with a flatfield correction
-    will take img and return 
+    will take img and return
     img_out = img * max(ff) / (ff + .0001)
     converted back to the original type of img
 
@@ -62,13 +62,13 @@ def intensity_corr(img, ff,clip,scale_factor,clip_min,clip_max):
 
 
 def getImage(ts):
-    """Simple function to get the level 0 image of this tilespec 
+    """Simple function to get the level 0 image of this tilespec
     as a numpy array
 
     Parameters
     ==========
     ts: renderapi.tilespec.TileSpec
-        tilespec to get images from 
+        tilespec to get images from
         (presently assumes this is a tiff image whose URL can be read with tifffile)
 
     Returns
@@ -169,7 +169,16 @@ class MultIntensityCorr(RenderModule):
         # upload to render
         renderapi.stack.create_stack(
             self.args['output_stack'], cycleNumber=self.args['cycle_number'],
-             cycleStepNumber=self.args['cycle_step_number'], render=self.render)
+            cycleStepNumber=self.args['cycle_step_number'], render=self.render)
+
+        if self.args['overwrite_zlayer']:
+            try:
+                renderapi.stack.delete_section(
+                    self.args['output_stack'], self.args['z_index'],
+                    render=self.render)
+            except renderapi.errors.RenderError as e:
+                self.logger.error(e)
+
         renderapi.client.import_tilespecs_parallel(
             self.args['output_stack'], output_tilespecs,
             poolsize = self.args['pool_size'],render=self.render,close_stack=self.args['close_stack'])

--- a/rendermodules/intensity_correction/schemas.py
+++ b/rendermodules/intensity_correction/schemas.py
@@ -49,6 +49,10 @@ class MultIntensityCorrParams(RenderParameters):
                   description='Min Clip value')
     clip_max = Int(required=False, default=65535,
                   description='Max Clip value')
+    overwrite_zlayer = Bool(
+        required=False, default=False,
+        description=("whether to remove the existing layer from the "
+                     "target stack before uploading."))
 
 
 

--- a/rendermodules/lens_correction/apply_lens_correction.py
+++ b/rendermodules/lens_correction/apply_lens_correction.py
@@ -83,6 +83,16 @@ class ApplyLensCorrection(RenderModule):
 
         renderapi.stack.create_stack(outputStack, render=r)
         renderapi.stack.set_stack_state(outputStack, 'LOADING', render=r)
+
+        if self.args['overwrite_zlayer']:
+            for z in self.args['zs']:
+                try:
+                    renderapi.stack.delete_section(
+                        outputStack, z,
+                        render=self.render)
+                except renderapi.errors.RenderError as e:
+                    self.logger.error(e)
+
         renderapi.client.import_tilespecs_parallel(
             outputStack, new_tspecs, poolsize=self.args['pool_size'],
             close_stack=self.args['close_stack'], render=r)

--- a/rendermodules/lens_correction/schemas.py
+++ b/rendermodules/lens_correction/schemas.py
@@ -129,6 +129,11 @@ class ApplyLensCorrectionParameters(RenderParameters):
         required=False, default=False,
         description=("whether to set output stack to 'COMPLETE' "
                      "upon completion"))
+    overwrite_zlayer = Boolean(
+        required=False, default=False,
+        description=("whether to remove the existing layer from the "
+                     "target stack before uploading."))
+
 
 
 class ApplyLensCorrectionOutput(DefaultSchema):

--- a/rendermodules/stack/consolidate_transforms.py
+++ b/rendermodules/stack/consolidate_transforms.py
@@ -42,7 +42,7 @@ def dereference_tforms(tforms, ref_tforms):
             except StopIteration as e:
                 raise RenderModuleException(
                     ("reference transform: {} not found in provided refererence transforms {}".format(
-                                                                                                tf.refId, 
+                                                                                                tf.refId,
                                                                                                 ref_tforms)))
         else:
             deref_tforms.append(tf)
@@ -129,6 +129,14 @@ class ConsolidateTransforms(RenderModule):
         zvalues = zvalues[zvalues <= maxZ]
 
         self.render.run(renderapi.stack.create_stack, outstack)
+        if self.args['overwrite_zlayer']:
+            for z in zvalues:
+                try:
+                    renderapi.stack.delete_section(
+                        outstack, z, render=self.render)
+                except renderapi.errors.RenderError as e:
+                    self.logger.error(e)
+
         with renderapi.client.WithPool(self.args['pool_size']) as pool:
             resolved_tiles_list = pool.map(partial(
                 process_z,

--- a/rendermodules/stack/schemas.py
+++ b/rendermodules/stack/schemas.py
@@ -1,5 +1,5 @@
 from rendermodules.module.schemas import RenderParameters
-from argschema.fields import Str, Int, Slice, Float
+from argschema.fields import Str, Int, Slice, Float, Boolean
 from argschema.schemas import DefaultSchema
 
 class ConsolidateTransformsParameters(RenderParameters):
@@ -20,6 +20,11 @@ class ConsolidateTransformsParameters(RenderParameters):
     maxZ = Float(required=False,
                  description="""minimaximummum z to consolidate in read in from stack and write to output_stack\
                  default to maximum z in stack""")
+    overwrite_zlayer = Boolean(
+        required=False, default=False,
+        description=("whether to remove the existing layer from the "
+                     "target stack before uploading."))
+
 
 
 class ConsolidateTransformsOutputParameters(DefaultSchema):


### PR DESCRIPTION
adding option (defaulting to false) to overwrite z layers in the output stacks by deleting those zs prior to upload.  This allows for more meaningful reprocessing in a workflow application where many operations have the same source and sink stacks.