### PR TITLE
Rough align catch 2

### DIFF
--- a/integration_tests/test_data.py
+++ b/integration_tests/test_data.py
@@ -3,6 +3,8 @@ from jinja2 import Environment, FileSystemLoader
 import json
 import tempfile
 
+pool_size = os.environ.get('RENDERMODULES_POOL_SIZE',5)
+
 render_host = os.environ.get(
     'RENDER_HOST', 'renderservice')
 render_port = os.environ.get(

--- a/integration_tests/test_rough_align.py
+++ b/integration_tests/test_rough_align.py
@@ -211,6 +211,7 @@ def test_apply_rough_alignment_transform(render, montage_stack, test_do_rough_al
     ex1['minZ'] = 1020
     ex1['maxZ'] = 1022
     ex1['scale'] = 0.1
+    ex1['pool_size'] = 3
     ex1['output_json']=str(tmpdir_factory.mktemp('output').join('output.json'))
     ex1['loglevel']='DEBUG'
     

--- a/integration_tests/test_rough_align.py
+++ b/integration_tests/test_rough_align.py
@@ -228,6 +228,7 @@ def test_apply_rough_alignment_transform(render, montage_stack, test_do_rough_al
                           ex1['montage_stack'], 
                           ex1['montage_stack'],
                           ex1['lowres_stack'],
+                          ex1['output_stack'],
                           ex1['tilespec_directory'],
                           ex1['scale'],
                           (1020,1020),

--- a/integration_tests/test_rough_align.py
+++ b/integration_tests/test_rough_align.py
@@ -200,7 +200,8 @@ def test_point_match_collection(render, rough_point_match_collection):
     groupIds = render.run(renderapi.pointmatch.get_match_groupIds, rough_point_match_collection)
     assert(('1020.0' in groupIds) and ('1021.0' in groupIds) and ('1022.0' in groupIds))
 
-def test_apply_rough_alignment_transform(render, montage_stack, test_do_rough_alignment, tmpdir_factory, prealigned_stack=None, output_stack=None):
+def test_apply_rough_alignment_transform(render, montage_stack, test_do_rough_alignment, tmpdir, prealigned_stack=None, output_stack=None):
+    output_file = str(tmpdir.join('output.json'))
     ex1['render'] = render_params
     ex1['montage_stack'] = montage_stack
     ex1['lowres_stack'] = test_do_rough_alignment
@@ -210,6 +211,7 @@ def test_apply_rough_alignment_transform(render, montage_stack, test_do_rough_al
     ex1['minZ'] = 1020
     ex1['maxZ'] = 1022
     ex1['scale'] = 0.1
+    ex1['output_json']=output_file
     
     mod = ApplyRoughAlignmentTransform(input_data=ex1, args=[])
     mod.run()

--- a/integration_tests/test_rough_align.py
+++ b/integration_tests/test_rough_align.py
@@ -200,8 +200,8 @@ def test_point_match_collection(render, rough_point_match_collection):
     groupIds = render.run(renderapi.pointmatch.get_match_groupIds, rough_point_match_collection)
     assert(('1020.0' in groupIds) and ('1021.0' in groupIds) and ('1022.0' in groupIds))
 
-def test_apply_rough_alignment_transform(render, montage_stack, test_do_rough_alignment, tmpdir, prealigned_stack=None, output_stack=None):
-    output_file = str(tmpdir.join('output.json'))
+def test_apply_rough_alignment_transform(render, montage_stack, test_do_rough_alignment, tmpdir_factory, prealigned_stack=None, output_stack=None):
+
     ex1['render'] = render_params
     ex1['montage_stack'] = montage_stack
     ex1['lowres_stack'] = test_do_rough_alignment
@@ -211,7 +211,7 @@ def test_apply_rough_alignment_transform(render, montage_stack, test_do_rough_al
     ex1['minZ'] = 1020
     ex1['maxZ'] = 1022
     ex1['scale'] = 0.1
-    ex1['output_json']=output_file
+    ex1['output_json']=str(tmpdir_factory.mktemp('output').join('output.json'))
     
     mod = ApplyRoughAlignmentTransform(input_data=ex1, args=[])
     mod.run()

--- a/integration_tests/test_rough_align.py
+++ b/integration_tests/test_rough_align.py
@@ -212,6 +212,7 @@ def test_apply_rough_alignment_transform(render, montage_stack, test_do_rough_al
     ex1['maxZ'] = 1022
     ex1['scale'] = 0.1
     ex1['output_json']=str(tmpdir_factory.mktemp('output').join('output.json'))
+    ex1['loglevel']='DEBUG'
     
     mod = ApplyRoughAlignmentTransform(input_data=ex1, args=[])
     mod.run()

--- a/integration_tests/test_rough_align.py
+++ b/integration_tests/test_rough_align.py
@@ -10,7 +10,8 @@ from test_data import (ROUGH_MONTAGE_TILESPECS_JSON,
                        ROUGH_POINT_MATCH_COLLECTION,
                        ROUGH_DS_TEST_TILESPECS_JSON,
                        render_params,
-                       test_rough_parameters as solver_example)
+                       test_rough_parameters as solver_example,
+                       pool_size)
 
 from rendermodules.module.render_module import RenderModuleException
 from rendermodules.materialize.render_downsample_sections import RenderSectionAtScale, create_tilespecs_without_mipmaps
@@ -211,7 +212,7 @@ def test_apply_rough_alignment_transform(render, montage_stack, test_do_rough_al
     ex1['minZ'] = 1020
     ex1['maxZ'] = 1022
     ex1['scale'] = 0.1
-    ex1['pool_size'] = 3
+    ex1['pool_size'] = pool_size
     ex1['output_json']=str(tmpdir_factory.mktemp('output').join('output.json'))
     ex1['loglevel']='DEBUG'
     

--- a/rendermodules/rough_align/apply_rough_alignment_to_montages.py
+++ b/rendermodules/rough_align/apply_rough_alignment_to_montages.py
@@ -137,7 +137,6 @@ def apply_rough_alignment(render,
             if consolidateTransforms:
                 newt = consolidate_transforms(t.tforms)
                 t.tforms = newt
-            d1 = t.to_dict()
             t.z = newz
         
         renderapi.client.import_tilespecs(output_stack,highres_ts1,render=render)
@@ -169,13 +168,6 @@ class ApplyRoughAlignmentTransform(RenderModule):
 
         # the old and new z values are required for the AT team
         Z = [[a,b] for a,b in zip(zvalues, newzvalues)]
-
-        # delete existing json files in the tilespec directory
-        jsonfiles = glob.glob("%s/*.json"%self.args['tilespec_directory'])
-        for js in jsonfiles:
-            if os.path.exists(js):
-                cmd = "rm %s"%js
-                os.system(cmd)
 
         mypartial = partial(
                         apply_rough_alignment,

--- a/rendermodules/rough_align/apply_rough_alignment_to_montages.py
+++ b/rendermodules/rough_align/apply_rough_alignment_to_montages.py
@@ -210,7 +210,6 @@ class ApplyRoughAlignmentTransform(RenderModule):
                         self.args['lowres_stack'],
                         self.args['tilespec_directory'],
                         self.args['scale'],
-                        self.logger,
                         consolidateTransforms=self.args['consolidate_transforms'])
 
         with renderapi.client.WithPool(self.args['pool_size']) as pool:

--- a/rendermodules/rough_align/apply_rough_alignment_to_montages.py
+++ b/rendermodules/rough_align/apply_rough_alignment_to_montages.py
@@ -223,7 +223,7 @@ class ApplyRoughAlignmentTransform(RenderModule):
 
         #raise an exception if all the z values to apply alignment were not 
         if not all([r is None for r in results]):
-            failed_zs = [result,z for result,z in zip(results,Z) if result is not None]
+            failed_zs = [(result,z) for result,z in zip(results,Z) if result is not None]
             raise RenderModuleException("Failed to rough align z values {}".format(failed_zs))
 
         jsonfiles = glob.glob("%s/*.json"%self.args['tilespec_directory'])

--- a/rendermodules/rough_align/apply_rough_alignment_to_montages.py
+++ b/rendermodules/rough_align/apply_rough_alignment_to_montages.py
@@ -247,7 +247,7 @@ class ApplyRoughAlignmentTransform(RenderModule):
             self.args['output_stack'],
             state='COMPLETE')
 
-        self.output({'zs',np.array(Z)})
+        self.output({'zs':np.array(Z)})
 
 if __name__ == "__main__":
     mod = ApplyRoughAlignmentTransform(input_data=example)

--- a/rendermodules/rough_align/apply_rough_alignment_to_montages.py
+++ b/rendermodules/rough_align/apply_rough_alignment_to_montages.py
@@ -247,7 +247,12 @@ class ApplyRoughAlignmentTransform(RenderModule):
             self.args['output_stack'],
             state='COMPLETE')
 
-        self.output({'zs':np.array(Z)})
+        self.output(
+            {
+            'zs':np.array(Z),
+            'output_stack':self.args['output_stack']
+            }
+        )
 
 if __name__ == "__main__":
     mod = ApplyRoughAlignmentTransform(input_data=example)

--- a/rendermodules/rough_align/apply_rough_alignment_to_montages.py
+++ b/rendermodules/rough_align/apply_rough_alignment_to_montages.py
@@ -8,7 +8,7 @@ from ..module.render_module import RenderModule, RenderModuleException
 from rendermodules.rough_align.schemas import ApplyRoughAlignmentTransformParameters, ApplyRoughAlignmentOutputParameters
 from rendermodules.stack.consolidate_transforms import consolidate_transforms
 from functools import partial
-
+import logging
 
 if __name__ == "__main__" and __package__ is None:
     __package__ = "rendermodules.rough_align.apply_rough_alignment_to_montages"
@@ -71,6 +71,7 @@ def consolidate_transforms(tforms, verbose=False, makePolyDegree=0):
 
     return new_tform_list
 '''
+logger = logging.getLogger('rendermodules')
 
 def apply_rough_alignment(render,
                           input_stack,
@@ -86,11 +87,12 @@ def apply_rough_alignment(render,
 
     try:
         # get lowres stack tile specs
+        logger.debug('getting tilespecs from {} z={}'.format(lowres_stack,z))
         lowres_ts = render.run(
                             renderapi.tilespec.get_tile_specs_from_z,
                             lowres_stack,
                             z)
-
+        
         # get the lowres stack rough alignment transformation
         tforms = lowres_ts[0].tforms
         tf = tforms[-1]
@@ -117,7 +119,8 @@ def apply_rough_alignment(render,
         translation_tform = renderapi.transform.AffineModel(B0=tx,B1=ty)     
 
         ftform = [translation_tform] + tforms
-        
+        logger.debug('getting tilespecs from {} z={}'.format(lowres_stack,z))
+
         highres_ts1 = render.run(
                             renderapi.tilespec.get_tile_specs_from_z,
                             input_stack,

--- a/rendermodules/rough_align/apply_rough_alignment_to_montages.py
+++ b/rendermodules/rough_align/apply_rough_alignment_to_montages.py
@@ -78,7 +78,6 @@ def apply_rough_alignment(render,
                           lowres_stack,
                           output_dir,
                           scale,
-                          logger,
                           Z,
                           consolidateTransforms=True):
     z = Z[0]
@@ -167,9 +166,9 @@ def apply_rough_alignment(render,
         fp = open(tilespecfilename,'w')
         json.dump([ts for ts in allts], fp, indent=4)
         fp.close()
-        return True
+        return None
     except Exception as e:
-        logger.error("z={} encountered exception({})".format(Z,e))
+        return e
 
 
 
@@ -223,8 +222,8 @@ class ApplyRoughAlignmentTransform(RenderModule):
             results=pool.map(mypartial, Z)
 
         #raise an exception if all the z values to apply alignment were not 
-        if not all(results):
-            failed_zs = [z for result,z in zip(results,Z) if not result]
+        if not all([r is None for r in results]):
+            failed_zs = [result,z for result,z in zip(results,Z) if result is not None]
             raise RenderModuleException("Failed to rough align z values {}".format(failed_zs))
 
         jsonfiles = glob.glob("%s/*.json"%self.args['tilespec_directory'])

--- a/rendermodules/rough_align/apply_rough_alignment_to_montages.py
+++ b/rendermodules/rough_align/apply_rough_alignment_to_montages.py
@@ -5,7 +5,7 @@ import renderapi
 import glob
 import numpy as np
 from ..module.render_module import RenderModule, RenderModuleException
-from rendermodules.rough_align.schemas import ApplyRoughAlignmentTransformParameters
+from rendermodules.rough_align.schemas import ApplyRoughAlignmentTransformParameters, ApplyRoughAlignmentOutputParameters
 from rendermodules.stack.consolidate_transforms import consolidate_transforms
 from functools import partial
 
@@ -174,7 +174,7 @@ def apply_rough_alignment(render,
 
 class ApplyRoughAlignmentTransform(RenderModule):
     default_schema = ApplyRoughAlignmentTransformParameters
-    default_output_schema = 
+    default_output_schema = ApplyRoughAlignmentOutputParameters
     def run(self):
         if self.args['minZ'] >= self.args['maxZ']:
             raise RenderModuleException("First section z cannot be greater or equal to last section z")

--- a/rendermodules/rough_align/apply_rough_alignment_to_montages.py
+++ b/rendermodules/rough_align/apply_rough_alignment_to_montages.py
@@ -89,21 +89,13 @@ def apply_rough_alignment(render,
         lowres_ts = render.run(
                             renderapi.tilespec.get_tile_specs_from_z,
                             lowres_stack,
-                            newz)
+                            z)
 
         # get the lowres stack rough alignment transformation
         tforms = lowres_ts[0].tforms
-        d = tforms[-1].to_dict()
+        tf = tforms[-1]
+        tf.M[0:2,0:2]*=scale
         
-        dsList = d['dataString'].split()
-        v0 = float(dsList[0])*scale
-        v1 = float(dsList[1])*scale
-        v2 = float(dsList[2])*scale
-        v3 = float(dsList[3])*scale
-        v4 = float(dsList[4])
-        v5 = float(dsList[5])
-        d['dataString'] = "%f %f %f %f %s %s"%(v0, v1, v2, v3, v4, v5)
-        tforms[-1].from_dict(d)
         stackbounds = render.run(
                             renderapi.stack.get_bounds_from_z,
                             input_stack,

--- a/rendermodules/rough_align/apply_rough_alignment_to_montages.py
+++ b/rendermodules/rough_align/apply_rough_alignment_to_montages.py
@@ -225,7 +225,7 @@ class ApplyRoughAlignmentTransform(RenderModule):
         #raise an exception if all the z values to apply alignment were not 
         if not all(results):
             failed_zs = [z for result,z in zip(results,Z) if not result]
-            raise RenderModuleException("Failed to rough align z values {}".format(failed_zs)
+            raise RenderModuleException("Failed to rough align z values {}".format(failed_zs))
 
         jsonfiles = glob.glob("%s/*.json"%self.args['tilespec_directory'])
         

--- a/rendermodules/rough_align/apply_rough_alignment_to_montages.py
+++ b/rendermodules/rough_align/apply_rough_alignment_to_montages.py
@@ -174,7 +174,7 @@ def apply_rough_alignment(render,
 
 class ApplyRoughAlignmentTransform(RenderModule):
     default_schema = ApplyRoughAlignmentTransformParameters
-
+    default_output_schema = 
     def run(self):
         if self.args['minZ'] >= self.args['maxZ']:
             raise RenderModuleException("First section z cannot be greater or equal to last section z")
@@ -247,6 +247,7 @@ class ApplyRoughAlignmentTransform(RenderModule):
             self.args['output_stack'],
             state='COMPLETE')
 
+        self.output({'zs',np.array(Z)})
 
 if __name__ == "__main__":
     mod = ApplyRoughAlignmentTransform(input_data=example)

--- a/rendermodules/rough_align/apply_rough_alignment_to_montages.py
+++ b/rendermodules/rough_align/apply_rough_alignment_to_montages.py
@@ -173,12 +173,7 @@ def apply_rough_alignment(render,
 
 
 class ApplyRoughAlignmentTransform(RenderModule):
-    def __init__(self, schema_type=None, *args, **kwargs):
-        if schema_type is None:
-            schema_type = ApplyRoughAlignmentTransformParameters
-        super(ApplyRoughAlignmentTransform, self).__init__(
-            schema_type=schema_type, *args, **kwargs)
-
+    default_schema = ApplyRoughAlignmentTransformParameters
 
     def run(self):
         if self.args['minZ'] >= self.args['maxZ']:

--- a/rendermodules/rough_align/schemas.py
+++ b/rendermodules/rough_align/schemas.py
@@ -428,4 +428,4 @@ class SolveRoughAlignmentParameters(RenderParameters):
 
 class ApplyRoughAlignmentOutputParameters(DefaultSchema):
     zs = argschema.fields.NumpyArray(description="list of z values that were applied to")
-    
+    output_stack = argschema.fields.Str(descriptoin="stack where applied trasforms were set")

--- a/rendermodules/rough_align/schemas.py
+++ b/rendermodules/rough_align/schemas.py
@@ -428,4 +428,4 @@ class SolveRoughAlignmentParameters(RenderParameters):
 
 class ApplyRoughAlignmentOutputParameters(DefaultSchema):
     zs = argschema.fields.NumpyArray(description="list of z values that were applied to")
-    output_stack = argschema.fields.Str(descriptoin="stack where applied trasforms were set")
+    output_stack = argschema.fields.Str(description="stack where applied transforms were set")

--- a/rendermodules/rough_align/schemas.py
+++ b/rendermodules/rough_align/schemas.py
@@ -425,3 +425,7 @@ class SolveRoughAlignmentParameters(RenderParameters):
                 data['solver_options']['pastix']['ncpus'] = 8
             if pastix['split'] is None:
                 data['solver_options']['pastix']['split'] = 1
+
+class ApplyRoughAlignmentOutputParameters(DefaultSchema):
+    zs = argschema.fields.NumpyArray(description="list of z values that were applied to")
+    

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 import sys
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
-
+import logging
 
 class PyTest(TestCommand):
     user_options = [('pytest-args=', 'a', "Arguments to pass to pytest")]
@@ -17,7 +17,8 @@ class PyTest(TestCommand):
         import pytest
         self.pytest_args += " --cov=rendermodules --cov-report html "\
                             "--junitxml=test-reports/test.xml"
-
+        FORMAT = "[%(filename)s:%(lineno)s - %(funcName)20s() ] %(message)s"
+        logging.basicConfig(format=FORMAT)
         errno = pytest.main(shlex.split(self.pytest_args))
         sys.exit(errno)
 


### PR DESCRIPTION
I changed code to catch the exceptions that were thrown in the function. This revealed several bugs in the original tests that weren't passing correctly, including the set_new_z option, and some tests were failing due to incoherent json... not sure precisely why, but reengineering the code to use the import_tilespecs. I also fixed the fact that the there was no output_json. I also simplified some of the tilespec construction.