### PR TITLE
Simplify schemas

### DIFF
--- a/integration_tests/test_dataimport.py
+++ b/integration_tests/test_dataimport.py
@@ -14,6 +14,7 @@ from rendermodules.dataimport import apply_mipmaps_to_render
 from test_data import (render_params,
                        METADATA_FILE, MIPMAP_TILESPECS_JSON, scratch_dir)
 import os
+import copy
 
 @pytest.fixture(scope='module')
 def render():
@@ -23,7 +24,7 @@ def test_generate_EM_metadata(render):
     assert isinstance(render, renderapi.render.RenderClient)
     with open(METADATA_FILE, 'r') as f:
         md = json.load(f)
-    ex = generate_EM_tilespecs_from_metafile.example_input
+    ex = copy.copy(generate_EM_tilespecs_from_metafile.example_input)
     ex['render'] = render.make_kwargs()
     ex['metafile'] = METADATA_FILE
     with tempfile.NamedTemporaryFile(suffix='.json') as probablyemptyfn:
@@ -81,7 +82,7 @@ def outfile_test_and_remove(f, output_fn):
     return val
 
 def apply_generated_mipmaps(r, output_stack, generate_params,z=None):
-    ex = apply_mipmaps_to_render.example
+    ex = copy.copy(apply_mipmaps_to_render.example)
     ex['render'] = r.make_kwargs()
     ex['input_stack'] = generate_params['input_stack']
     ex['output_stack'] = output_stack
@@ -177,7 +178,7 @@ def test_mipmaps(render, input_stack, tspecs_to_mipmap, output_stack=None):
     output_stack = ('{}OUT'.format(input_stack) if output_stack
                     is None else output_stack)
 
-    ex = generate_mipmaps.example
+    ex = copy.copy(generate_mipmaps.example)
     ex['render'] = render.make_kwargs()
     ex['input_stack'] = input_stack
     ex['zstart'] = min([ts.z for ts in tspecs_to_mipmap])
@@ -201,7 +202,7 @@ def test_make_mipmaps_single_z(render, input_stack, tspecs_to_mipmap, tmpdir,out
     output_stack = ('{}OUTSINGLEZ'.format(input_stack) if output_stack
                     is None else output_stack)
 
-    ex = generate_mipmaps.example
+    ex = copy.copy(generate_mipmaps.example)
     ex['render'] = render.make_kwargs()
     ex['input_stack'] = input_stack
     ex['z'] = min([ts.z for ts in tspecs_to_mipmap])
@@ -225,7 +226,7 @@ def test_make_mipmaps_single_z(render, input_stack, tspecs_to_mipmap, tmpdir,out
         mod.run()
 
 def test_make_mipmaps_fail_no_z(render,input_stack,tmpdir):
-    ex = generate_mipmaps.example
+    ex = copy.copy(generate_mipmaps.example)
     ex['render'] = render.make_kwargs()
     ex['input_stack'] = input_stack
     ex['output_dir'] = scratch_dir

--- a/integration_tests/test_em_montage.py
+++ b/integration_tests/test_em_montage.py
@@ -127,7 +127,6 @@ def test_point_match_generation(render, test_create_montage_tile_pairs,tmpdir_fa
     mod.run()
     with open(pointmatch_example['output_json'],'r') as fp:
         output_d = json.load(fp)
-    print output_d
     assert (output_d['pairCount']>0)
     yield pointmatch_example['collection']
 

--- a/integration_tests/test_em_montage.py
+++ b/integration_tests/test_em_montage.py
@@ -127,6 +127,7 @@ def test_point_match_generation(render, test_create_montage_tile_pairs,tmpdir_fa
     mod.run()
     with open(pointmatch_example['output_json'],'r') as fp:
         output_d = json.load(fp)
+    print output_d
     assert (output_d['pairCount']>0)
     yield pointmatch_example['collection']
 
@@ -195,7 +196,7 @@ def test_fail_montage_job_for_section(render,
     with pytest.raises(RenderModuleException):
         mod = SolveMontageSectionModule(input_data=solver_example, args=[])
         mod.run()
-    
+
     # code coverage for schema
     solver_example['render']['host'] = 'http://' + solver_example['render']['host']
     mod = SolveMontageSectionModule(input_data=solver_example, args=[])

--- a/integration_tests/test_lens_correction.py
+++ b/integration_tests/test_lens_correction.py
@@ -153,7 +153,7 @@ def test_apply_lens_correction(render, stack_no_lc, stack_lc, example_tform_dict
     test_example_tform = example_tform.tform(test_points)
 
     for z in params['zs']:
-        tspecs = renderapi.tilespec.get_tile_specs_from_z(params['outputStack'], z, render=render)
+        tspecs = renderapi.tilespec.get_tile_specs_from_z(params['output_stack'], z, render=render)
 
         for ts in tspecs:
             new_tform_dict = ts.tforms[0].to_dict()

--- a/integration_tests/test_materialize.py
+++ b/integration_tests/test_materialize.py
@@ -4,6 +4,7 @@
 import json
 import os
 import imghdr
+import copy
 
 import pytest
 
@@ -52,7 +53,7 @@ def test_materialize_boxes(render, input_materializeboxes_stack, tmpdir):
     zs_totest = renderapi.stack.get_z_values_for_stack(
         input_materializeboxes_stack, render=render)
 
-    input_params = dict(materialize_sections.example_input, **{
+    input_params = dict(copy.copy(materialize_sections.example_input), **{
         'stack': input_materializeboxes_stack,
         'render': {
             'owner': render_params['owner'],

--- a/integration_tests/test_multiplicative_correction.py
+++ b/integration_tests/test_multiplicative_correction.py
@@ -113,7 +113,8 @@ def test_apply_correction(test_median_stack, mini_raw_stack, render, tmpdir_fact
 def test_single_tile(test_apply_correction,render,tmpdir):
 
     # get tilespecs
-    Z = test_apply_correction.args['z_index']
+    # Z = test_apply_correction.args['z_index']
+    Z = test_apply_correction.zValues[0]
     inp_tilespecs = renderapi.tilespec.get_tile_specs_from_z(
         test_apply_correction.args['input_stack'], Z, render=test_apply_correction.render)
     corr_tilespecs = renderapi.tilespec.get_tile_specs_from_z(

--- a/integration_tests/test_rough_align.py
+++ b/integration_tests/test_rough_align.py
@@ -5,6 +5,7 @@ import logging
 import renderapi
 import json
 import glob
+import copy
 import marshmallow as mm
 from test_data import (ROUGH_MONTAGE_TILESPECS_JSON,
                        ROUGH_POINT_MATCH_COLLECTION,
@@ -17,7 +18,7 @@ from rendermodules.module.render_module import RenderModuleException
 from rendermodules.materialize.render_downsample_sections import RenderSectionAtScale, create_tilespecs_without_mipmaps
 from rendermodules.dataimport.make_montage_scapes_stack import MakeMontageScapeSectionStack
 from rendermodules.rough_align.do_rough_alignment import SolveRoughAlignmentModule
-from rendermodules.rough_align.apply_rough_alignment_to_montages import (ApplyRoughAlignmentTransform, 
+from rendermodules.rough_align.apply_rough_alignment_to_montages import (ApplyRoughAlignmentTransform,
                                                                          example as ex1,
                                                                          apply_rough_alignment)
 
@@ -50,11 +51,11 @@ def tspecs():
 def montage_stack(render,tspecs_from_json):
     test_montage_stack = 'input_montage_stack'
     renderapi.stack.create_stack(test_montage_stack, render=render)
-    renderapi.client.import_tilespecs(test_montage_stack, 
-                                      tspecs_from_json, 
+    renderapi.client.import_tilespecs(test_montage_stack,
+                                      tspecs_from_json,
                                       render=render)
-    renderapi.stack.set_stack_state(test_montage_stack, 
-                                    'COMPLETE', 
+    renderapi.stack.set_stack_state(test_montage_stack,
+                                    'COMPLETE',
                                     render=render)
 
     # assure stack is built correctly
@@ -62,7 +63,7 @@ def montage_stack(render,tspecs_from_json):
                 in tspecs_from_json}.symmetric_difference(set(
                     renderapi.stack.get_stack_tileIds(
                         test_montage_stack, render=render)))) == 0
-    
+
     zvalues = render.run(renderapi.stack.get_z_values_for_stack,
                           test_montage_stack)
     zs = [1020, 1021, 1022]
@@ -75,18 +76,18 @@ def montage_stack(render,tspecs_from_json):
 def one_tile_montage(render, tspecs):
     one_tile_montage_stack = 'one_tile_montage_stack'
     renderapi.stack.create_stack(one_tile_montage_stack, render=render)
-    renderapi.client.import_tilespecs(one_tile_montage_stack, 
-                                      tspecs, 
+    renderapi.client.import_tilespecs(one_tile_montage_stack,
+                                      tspecs,
                                       render=render)
-    renderapi.stack.set_stack_state(one_tile_montage_stack, 
-                                    'COMPLETE', 
+    renderapi.stack.set_stack_state(one_tile_montage_stack,
+                                    'COMPLETE',
                                     render=render)
     # assure stack is built correctly
     assert len({tspec.tileId for tspec
                 in tspecs}.symmetric_difference(set(
                     renderapi.stack.get_stack_tileIds(
                         one_tile_montage_stack, render=render)))) == 0
-    
+
     yield one_tile_montage_stack
     render.run(renderapi.stack.delete_stack, one_tile_montage_stack)
 
@@ -111,15 +112,15 @@ def downsample_sections_dir(montage_stack, tmpdir_factory):
 
     out_dir = os.path.join(image_directory, render_params['project'], montage_stack, 'sections_at_0.1/001/0')
     assert(os.path.exists(out_dir))
-    
+
     files = glob.glob(os.path.join(out_dir, '*.png'))
-    
+
     assert(len(files) == len(range(ex['minZ'], ex['maxZ']+1)))
 
     for fil in files:
         img = os.path.join(out_dir, fil)
         assert(os.path.exists(img) and os.path.isfile(img) and os.path.getsize(img) > 0)
-    
+
     yield image_directory
 
 
@@ -158,7 +159,7 @@ def rough_point_match_collection(render, rough_point_matches_from_json):
     renderapi.pointmatch.import_matches(pt_match_collection,
                                         rough_point_matches_from_json,
                                         render=render)
-    
+
     # check if point matches have been imported properly
     groupIds = render.run(renderapi.pointmatch.get_match_groupIds, pt_match_collection)
     #assert(len(groupIds) == 3)
@@ -171,19 +172,30 @@ def test_do_rough_alignment(render, montage_scape_stack, rough_point_match_colle
         output_lowres_stack = '{}_DS_Rough'.format(montage_scape_stack)
 
     output_directory = str(tmpdir_factory.mktemp('output_json'))
-    solver_example['output_json']=os.path.join(output_directory,'output.json')
+    solver_ex = dict(solver_example, **{
+        'output_json': os.path.join(output_directory,'output.json'),
+        'source_collection': dict(solver_example['source_collection'], **{
+            'stack': montage_scape_stack}),
+        'target_collection': dict(solver_example['target_collection'], **{
+            'stack': output_lowres_stack}),
+        'source_point_match_collection': dict(
+            solver_example['source_point_match_collection'], **{
+                'match_collection': rough_point_match_collection
+            })
+    })
+    """
+    solver_ex = copy.copy(solver_example)
+    solver_ex['output_json']=os.path.join(output_directory,'output.json')
 
-    solver_example['source_collection']['stack'] = montage_scape_stack
-    solver_example['target_collection']['stack'] = output_lowres_stack
-    solver_example['source_point_match_collection']['match_collection'] = rough_point_match_collection
+    solver_ex['source_collection']['stack'] = montage_scape_stack
+    solver_ex['target_collection']['stack'] = output_lowres_stack
+    solver_ex['source_point_match_collection']['match_collection'] = rough_point_match_collection
+    """
 
-       
-    mod = SolveRoughAlignmentModule(input_data=solver_example, args=[])
+
+    mod = SolveRoughAlignmentModule(input_data=solver_ex, args=[])
     mod.run()
 
-    zend = solver_example['first_section']
-    zstart = solver_example['last_section']
-    
     zvalues = render.run(renderapi.stack.get_z_values_for_stack, output_lowres_stack)
     zs = [1020, 1021, 1022]
     assert(set(zvalues) == set(zs))
@@ -191,72 +203,71 @@ def test_do_rough_alignment(render, montage_scape_stack, rough_point_match_colle
     yield output_lowres_stack
     renderapi.stack.delete_stack(output_lowres_stack, render=render)
 
-    
+
 def test_montage_scape_stack(render, montage_scape_stack):
     zvalues = render.run(renderapi.stack.get_z_values_for_stack, montage_scape_stack)
     zs = [1020, 1021, 1022]
-    assert(set(zvalues)==set(zs)) 
-    
+    assert(set(zvalues)==set(zs))
+
 def test_point_match_collection(render, rough_point_match_collection):
     groupIds = render.run(renderapi.pointmatch.get_match_groupIds, rough_point_match_collection)
     assert(('1020.0' in groupIds) and ('1021.0' in groupIds) and ('1022.0' in groupIds))
 
 def test_apply_rough_alignment_transform(render, montage_stack, test_do_rough_alignment, tmpdir_factory, prealigned_stack=None, output_stack=None):
 
-    ex1['render'] = render_params
-    ex1['montage_stack'] = montage_stack
-    ex1['lowres_stack'] = test_do_rough_alignment
-    ex1['prealigned_stack'] = None
-    ex1['output_stack'] = '{}_Rough'.format(montage_stack)
-    ex1['tilespec_directory'] = str(tmpdir_factory.mktemp('scratch'))
-    ex1['minZ'] = 1020
-    ex1['maxZ'] = 1022
-    ex1['scale'] = 0.1
-    ex1['pool_size'] = pool_size
-    ex1['output_json']=str(tmpdir_factory.mktemp('output').join('output.json'))
-    ex1['loglevel']='DEBUG'
-    
-    mod = ApplyRoughAlignmentTransform(input_data=ex1, args=[])
+    ex = dict(ex1, **{
+        'render': dict(ex1['render'], **render_params),
+        'montage_stack': montage_stack,
+        'lowres_stack': test_do_rough_alignment,
+        'prealigned_stack': None,
+        'output_stack': '{}_Rough'.format(montage_stack),
+        'tilespec_directory': str(tmpdir_factory.mktemp('scratch')),
+        'minZ': 1020,
+        'maxZ': 1022,
+        'scale': 0.1,
+        'pool_size': pool_size,
+        'output_json': str(tmpdir_factory.mktemp('output').join('output.json')),
+        'loglevel': 'DEBUG'
+    })
+    ex2 = dict(ex, **{'minZ': 1022, 'maxZ': 1020})
+    ex3 = dict(ex, **{'set_new_z': True})
+
+    mod = ApplyRoughAlignmentTransform(input_data=ex, args=[])
     mod.run()
 
-    zend = ex1['maxZ']
-    zstart = ex1['minZ']
+    zend = ex['maxZ']
+    zstart = ex['minZ']
 
-    zvalues = render.run(renderapi.stack.get_z_values_for_stack, ex1['output_stack'])
+    zvalues = render.run(renderapi.stack.get_z_values_for_stack, ex['output_stack'])
     zs = range(zstart, zend+1)
 
     assert(set(zvalues) == set(zs))
 
-    apply_rough_alignment(render, 
-                          ex1['montage_stack'], 
-                          ex1['montage_stack'],
-                          ex1['lowres_stack'],
-                          ex1['output_stack'],
-                          ex1['tilespec_directory'],
-                          ex1['scale'],
+    apply_rough_alignment(render,
+                          ex['montage_stack'],
+                          ex['montage_stack'],
+                          ex['lowres_stack'],
+                          ex['output_stack'],
+                          ex['tilespec_directory'],
+                          ex['scale'],
                           (1020,1020),
                           consolidateTransforms=True)
 
     # running again for code coverage
     mod.run()
 
-    ex1['minZ'] = 1022
-    ex1['maxZ'] = 1020
 
-    mod = ApplyRoughAlignmentTransform(input_data=ex1, args=[])
+    mod = ApplyRoughAlignmentTransform(input_data=ex2, args=[])
     with pytest.raises(RenderModuleException):
         mod.run()
 
-    ex1['set_new_z'] = True
-    ex1['minZ'] = 1020
-    ex1['maxZ'] = 1022
-    mod = ApplyRoughAlignmentTransform(input_data=ex1, args=[])
+    mod = ApplyRoughAlignmentTransform(input_data=ex3, args=[])
     mod.run()
 
 
 # additional tests for code coverage
 
-def test_render_downsample_with_mipmaps(render, one_tile_montage, tmpdir_factory):
+def test_render_downsample_with_mipmaps(render, one_tile_montage, tmpdir_factory, test_do_rough_alignment, montage_stack):
     image_directory = str(tmpdir_factory.mktemp('rough'))
     ex = {
         "render": render_params,
@@ -269,6 +280,9 @@ def test_render_downsample_with_mipmaps(render, one_tile_montage, tmpdir_factory
     }
     ex['output_json'] = os.path.join(image_directory, 'output.json')
 
+    ex2 = dict(ex, **{'minZ': 1021, 'maxZ': 1020})
+    ex3 = dict(ex2, **{'minZ': 1 , 'maxZ': 2})
+
     #stack_has_mipmaps = check_stack_for_mipmaps(render, ex['input_stack'], [1020])
     tempjson = create_tilespecs_without_mipmaps(render, ex['input_stack'], 0, 1020)
 
@@ -277,42 +291,51 @@ def test_render_downsample_with_mipmaps(render, one_tile_montage, tmpdir_factory
 
     with open(ex['output_json'], 'r') as f:
         js = json.load(f)
-    
+
     out_dir = os.path.join(image_directory, render_params['project'], js['temp_stack'], 'sections_at_0.1/001/0')
     assert(os.path.exists(out_dir))
-    
+
     files = glob.glob(os.path.join(out_dir, '*.png'))
     for fil in files:
         img = os.path.join(out_dir, fil)
         assert(os.path.exists(img) and os.path.isfile(img) and os.path.getsize(img) > 0)
-    
-    ex['minZ'] = 1021
-    ex['maxZ'] = 1020
-    mod = RenderSectionAtScale(input_data=ex, args=[])
-    with pytest.raises(RenderModuleException):
-        mod.run()
-    
-    ex['minZ'] = 1
-    ex['maxZ'] = 2
-    mod = RenderSectionAtScale(input_data=ex, args=[])
+
+    mod = RenderSectionAtScale(input_data=ex2, args=[])
     with pytest.raises(RenderModuleException):
         mod.run()
 
-    ex1['set_new_z'] = False
-    ex1['output_stack'] = 'failed_output'
+    mod = RenderSectionAtScale(input_data=ex3, args=[])
     with pytest.raises(RenderModuleException):
-        renderapi.stack.set_stack_state(ex1['lowres_stack'],'LOADING',render=render)
-        renderapi.stack.delete_section(ex1['lowres_stack'],1021,render=render)
-        renderapi.stack.set_stack_state(ex1['lowres_stack'],'COMPLETE',render=render)
-        mod = ApplyRoughAlignmentTransform(input_data=ex1, args=[])
         mod.run()
-        zvalues = renderapi.stack.get_z_values_for_stack(ex1['output_stack'],render=render)
+
+    ex2 = dict(ex1, **{
+        'set_new_z': False,
+        'output_stack': 'failed_output',
+        'render': dict(ex1['render'], **render_params),
+        'montage_stack': montage_stack,
+        'lowres_stack': test_do_rough_alignment,
+        'prealigned_stack': None,
+        'tilespec_directory': str(tmpdir_factory.mktemp('scratch')),
+        'minZ': 1020,
+        'maxZ': 1022,
+        'scale': 0.1,
+        'pool_size': pool_size,
+        'output_json': str(tmpdir_factory.mktemp('output').join('output.json')),
+        'loglevel': 'DEBUG'
+        })
+    with pytest.raises(RenderModuleException):
+        renderapi.stack.set_stack_state(ex2['lowres_stack'],'LOADING',render=render)
+        renderapi.stack.delete_section(ex2['lowres_stack'],1021,render=render)
+        renderapi.stack.set_stack_state(ex2['lowres_stack'],'COMPLETE',render=render)
+        mod = ApplyRoughAlignmentTransform(input_data=ex2, args=[])
+        mod.run()
+        zvalues = renderapi.stack.get_z_values_for_stack(ex2['output_stack'],render=render)
         assert(1021 not in zvalues)
 
 def test_make_montage_stack_without_downsamples(render, one_tile_montage, tmpdir_factory):
     # testing for make montage scape stack without having downsamples generated
     tmp_dir = str(tmpdir_factory.mktemp('downsample'))
-    output_stack = '{}_Downsample'.format(one_tile_montage) 
+    output_stack = '{}_Downsample'.format(one_tile_montage)
     params = {
         "render": render_params,
         "montage_stack": one_tile_montage,
@@ -326,8 +349,8 @@ def test_make_montage_stack_without_downsamples(render, one_tile_montage, tmpdir
     outjson = 'test_montage_scape_output.json'
     mod = MakeMontageScapeSectionStack(input_data=params, args=['--output_json', outjson])
     mod.run()
-    
-    
+
+
 
 def test_make_montage_scape_stack_fail(render, montage_stack, downsample_sections_dir):
     output_stack = '{}_DS'.format(montage_stack)
@@ -343,15 +366,16 @@ def test_make_montage_scape_stack_fail(render, montage_stack, downsample_section
         "zstart": 1020,
         "zend": 1022
     }
+    params_RMEx = dict(params, **{'set_new_z': False, 'zstart': 1, 'zend': 2})
     outjson = 'test_montage_scape_output.json'
+
+    print params
     with pytest.raises(mm.ValidationError):
         mod = MakeMontageScapeSectionStack(input_data=params, args=['--output_json', outjson])
         mod.run()
 
-    params['set_new_z'] = False
-    params['zstart'] = 1
-    params['zend'] = 2
-    mod = MakeMontageScapeSectionStack(input_data=params, args=['--output_json', outjson])
+    mod = MakeMontageScapeSectionStack(input_data=params_RMEx,
+                                       args=['--output_json', outjson])
     with pytest.raises(RenderModuleException):
         mod.run()
 
@@ -371,31 +395,44 @@ def test_setting_new_z_montage_scape(render, montage_stack, downsample_sections_
     }
     outjson = 'test_montage_scape_output.json'
     with pytest.raises(mm.ValidationError):
+        print params
         mod = MakeMontageScapeSectionStack(input_data=params, args=['--output_json', outjson])
 
 def test_solver_default_options(render, montage_scape_stack, rough_point_match_collection, tmpdir_factory):
     output_lowres_stack = '{}_DS_Rough'.format(montage_scape_stack)
 
     output_directory = str(tmpdir_factory.mktemp('output_json'))
-    solver_example['output_json']=os.path.join(output_directory,'output.json')
 
-    solver_example['source_collection']['stack'] = montage_scape_stack
-    solver_example['source_collection']['owner'] = None
-    solver_example['source_collection']['project'] = None
-    solver_example['source_collection']['service_host'] = None
-    solver_example['source_collection']['baseURL'] = None
-    solver_example['source_collection']['renderbinPath'] = None
-    solver_example['target_collection']['stack'] = output_lowres_stack
-    solver_example['target_collection']['owner'] = None
-    solver_example['target_collection']['project'] = None
-    solver_example['target_collection']['service_host'] = None
-    solver_example['target_collection']['baseURL'] = None
-    solver_example['target_collection']['renderbinPath'] = None
-    solver_example['source_point_match_collection']['match_collection'] = rough_point_match_collection
-    solver_example['source_point_match_collection']['server'] = None
-    #solver_example['source_point_match_collection']['owner'] = None
-    solver_example['first_section'] = 1020
-    solver_example['last_section'] = 1020
+    solver_ex1 = dict(solver_example, **{
+        'output_json': os.path.join(output_directory,'output.json'),
+        'source_collection': dict(solver_example['source_collection'], **{
+            'stack': montage_scape_stack,
+            'owner': None,
+            'project': None,
+            'service_host': None,
+            'baseURL': None,
+            'renderbinPath': None}),
+        'target_collection': dict(solver_example['target_collection'], **{
+            'stack': output_lowres_stack,
+            'owner': None,
+            'project': None,
+            'service_host': None,
+            'baseURL': None,
+            'renderbinPath': None}),
+        'source_point_match_collection': dict(
+            solver_example['source_point_match_collection'], **{
+                'match_collection': rough_point_match_collection,
+                'server': None,
+                'owner': None
+            }),
+        'first_section': 1020,
+        'last_section': 1020})
+
+    solver_ex2 = dict(solver_ex1, **{
+        'first_section': 1022,
+        'last_section': 1020})
+
+    solver_ex3 = copy.copy(solver_ex2)
 
     solver_example['source_collection'].pop('owner', None)
     solver_example['source_collection'].pop('project', None)
@@ -408,22 +445,19 @@ def test_solver_default_options(render, montage_scape_stack, rough_point_match_c
     solver_example['target_collection'].pop('baseURL', None)
     solver_example['target_collection'].pop('renderbinPath', None)
     #solver_example['solver_options']['pastix'] = None
-    
-    mod = SolveRoughAlignmentModule(input_data=solver_example, args=[])
+
+    mod = SolveRoughAlignmentModule(input_data=solver_ex1, args=[])
 
     with pytest.raises(RenderModuleException):
         mod.run()
-    
-    solver_example['first_section'] = 1022
-    solver_example['last_section'] = 1020
 
-    mod = SolveRoughAlignmentModule(input_data=solver_example, args=[])
+    mod = SolveRoughAlignmentModule(input_data=solver_ex2, args=[])
 
     with pytest.raises(RenderModuleException):
         mod.run()
-    
+
     os.environ.pop('MCRROOT', None)
-    mod = SolveRoughAlignmentModule(input_data=solver_example, args=[])
+    mod = SolveRoughAlignmentModule(input_data=solver_ex3, args=[])
 
     with pytest.raises(mm.ValidationError):
         mod.run()

--- a/rendermodules/dataimport/apply_mipmaps_to_render.py
+++ b/rendermodules/dataimport/apply_mipmaps_to_render.py
@@ -69,13 +69,7 @@ class AddMipMapsToStack(StackTransitionModule):
 
     def run(self):
         self.logger.debug('Applying mipmaps to stack')
-
-        # get the list of z indices
-        zvalues = self.render.run(
-            renderapi.stack.get_z_values_for_stack, self.args['input_stack'])
-
-        zvalues = list(set(self.zValues).intersection(set(zvalues)))
-
+        zvalues = self.get_overlapping_inputstack_zvalues()
         if len(zvalues) == 0:
             self.logger.error('No sections found for stack {}'.format(
                 self.args['input_stack']))

--- a/rendermodules/dataimport/generate_mipmaps.py
+++ b/rendermodules/dataimport/generate_mipmaps.py
@@ -90,10 +90,13 @@ class GenerateMipMaps(StackInputModule):
     def run(self):
         self.logger.debug('Mipmap generation module')
 
+        """
         # get the list of z indices
         zvalues = self.render.run(renderapi.stack.get_z_values_for_stack,
                                   self.args['input_stack'])
         zvalues = list(set(self.zValues).intersection(set(zvalues)))
+        """
+        zvalues = self.get_overlapping_inputstack_zvalues()
         if not zvalues:
             raise RenderModuleException("No sections found for stack {} for specified zs".format(
                 self.args['input_stack']))

--- a/rendermodules/em_montage_qc/schemas.py
+++ b/rendermodules/em_montage_qc/schemas.py
@@ -1,11 +1,12 @@
-import marshmallow as mm
 import argschema
 from marshmallow import post_load
-from ..module.render_module import RenderParameters
-from argschema.fields import Bool, Float, Int, Str, InputDir, List
+from ..module.schemas import (RenderParameters, ZValueParameters,
+                              ProcessPoolParameters)
+from argschema.fields import Bool, Int, Str, InputDir
 
 
-class DetectMontageDefectsParameters(RenderParameters):
+class DetectMontageDefectsParameters(
+        RenderParameters, ZValueParameters, ProcessPoolParameters):
     prestitched_stack = Str(
         required=True,
         description='Pre stitched stack (raw stack)')
@@ -20,12 +21,6 @@ class DetectMontageDefectsParameters(RenderParameters):
         default=None,
         missing=None,
         description='Name of the match collection owner')
-    minZ = Int(
-        required=True,
-        description='start z index of section')
-    maxZ = Int(
-        required=True,
-        description='end z index of section')
     residual_threshold = Int(
         required=False,
         default=4,
@@ -51,17 +46,12 @@ class DetectMontageDefectsParameters(RenderParameters):
         default=None,
         missing=None,
         description="Folder to save the Bokeh plot defaults to /tmp directory")
-    pool_size = Int(
-        required=False,
-        default=10,
-        missing=10,
-        description='Number of cores for parallel processing')
-    
+
     @post_load
     def add_match_collection_owner(self, data):
         if data['match_collection_owner'] is None:
             data['match_collection_owner'] = data['render']['owner']
-            
+
 
 class DetectMontageDefectsParametersOutput(argschema.schemas.DefaultSchema):
     output_html = Str(
@@ -73,8 +63,8 @@ class DetectMontageDefectsParametersOutput(argschema.schemas.DefaultSchema):
         required=True,
         description='List of sections that passed QC')
     hole_sections = argschema.fields.List(
-        argschema.fields.Int, 
-        required=True, 
+        argschema.fields.Int,
+        required=True,
         description='List of z values which failed QC and has holes')
     gap_sections = argschema.fields.List(
         argschema.fields.Int,
@@ -85,7 +75,7 @@ class DetectMontageDefectsParametersOutput(argschema.schemas.DefaultSchema):
         required=True,
         description='List of z values which have seams detected')
     seam_centroids = argschema.fields.NumpyArray(
-        dtype='object', 
+        dtype='object',
         required=True,
         description='An array of (x,y) positions of seams for each section with seams')
 

--- a/rendermodules/intensity_correction/schemas.py
+++ b/rendermodules/intensity_correction/schemas.py
@@ -1,46 +1,25 @@
-from argschema.fields import InputFile, InputDir, Str, Float, Int, OutputDir, Bool
-from ..module.schemas import RenderParameters
+from argschema.fields import Str, Float, Int, Bool
+from ..module.schemas import StackTransitionParameters
 
-class MakeMedianParams(RenderParameters):
-    input_stack = Str(required=True,
-                      description='Input stack to derive median from')
+
+class MakeMedianParams(StackTransitionParameters):
     file_prefix = Str(required=False, default="Median",
                       description='File prefix for median image file that is saved')
     output_directory = Str(required=True,
                                  description='Output Directory for saving median image')
-    output_stack = Str(required=True,
-                       description='Output stack to save correction into')
-    minZ = Int(required=True,
-               description='z value for section')
-    maxZ = Int(required=True,
-               description='z value for section')
-    pool_size = Int(required=False, default=20,
-                    description='size of pool for parallel processing (default=20)')
-    close_stack = Bool(required=False, default=False,
-                       description="whether to close stack or not")
     num_images = Int (required=False,default=-1,
                              description="Number of images to randomly subsample to generate median")
 
-
-class MultIntensityCorrParams(RenderParameters):
-    input_stack = Str(required=True,
-                      description="Input stack")
-    output_stack = Str(required=True,
-                       description='Output stack')
+class MultIntensityCorrParams(StackTransitionParameters):
     correction_stack = Str(required=True,
                            description='Correction stack (usually median stack for AT data)')
     output_directory = Str(required=True,
                                  description='Directory for storing Images')
-    z_index = Int(required=True,
-                  description='z value for section')
-    pool_size = Int(required=False, default=20,
-                    description='size of pool for parallel processing (default=20)')
+    # TODO add create_stack metadata
     cycle_number = Int(required=False, default=2,
-                       description="what cycleNumber to upload for output_stack on render")
+                    description="what cycleNumber to upload for output_stack on render")
     cycle_step_number = Int(required=False, default=1,
-                            description="what cycleStepNumber to upload for output_stack on render")
-    close_stack = Bool(required=False, default=False,
-                       description="whether to close stack or not")
+                         description="what cycleStepNumber to upload for output_stack on render")
     clip = Bool(required=False, default=True,
                        description="whether to clip values")
     scale_factor = Float(required=False,default=1.0,
@@ -49,12 +28,6 @@ class MultIntensityCorrParams(RenderParameters):
                   description='Min Clip value')
     clip_max = Int(required=False, default=65535,
                   description='Max Clip value')
-    overwrite_zlayer = Bool(
-        required=False, default=False,
-        description=("whether to remove the existing layer from the "
-                     "target stack before uploading."))
-
-
 
     # move_input = Bool(required=False, default=False,
     #                   description="whether to move input tiles to new location")

--- a/rendermodules/lens_correction/apply_lens_correction.py
+++ b/rendermodules/lens_correction/apply_lens_correction.py
@@ -85,19 +85,7 @@ class ApplyLensCorrection(StackTransitionModule):
         renderapi.stack.create_stack(outputStack, render=r)
         renderapi.stack.set_stack_state(outputStack, 'LOADING', render=r)
 
-        if self.args['overwrite_zlayer']:
-            for z in self.zValues:
-                try:
-                    renderapi.stack.delete_section(
-                        outputStack, z,
-                        render=self.render)
-                except renderapi.errors.RenderError as e:
-                    self.logger.error(e)
-
-        renderapi.client.import_tilespecs_parallel(
-            outputStack, new_tspecs, poolsize=self.args['pool_size'],
-            close_stack=self.args['close_stack'], render=r)
-
+        self.output_tilespecs_to_stack(new_tspecs)
         # output dict
         output = {}
         output['stack'] = outputStack

--- a/rendermodules/lens_correction/schemas.py
+++ b/rendermodules/lens_correction/schemas.py
@@ -1,8 +1,8 @@
 from argschema import ArgSchema
-from argschema.fields import Bool, Float, Int, Nested, Str, InputFile, List, Boolean
+from argschema.fields import Bool, Float, Int, Nested, Str, InputFile
 from argschema.schemas import DefaultSchema
 from marshmallow.validate import OneOf
-from rendermodules.module.schemas import RenderParameters
+from rendermodules.module.schemas import StackTransitionParameters
 
 class SIFTParameters(DefaultSchema):
     initialSigma = Float(
@@ -107,33 +107,12 @@ class TransformParameters(DefaultSchema):
         description='mpicbg-compatible dataString')
 
 
-class ApplyLensCorrectionParameters(RenderParameters):
-    inputStack = Str(
-        required=True,
-        description='Render Stack with tiles that should be transformed')
-    outputStack = Str(
-        required=True,
-        description=('Render Stack to which transformed tiles will be added'))
-    zs = List(
-        Int, required=True,
-        description='z indices to which transform should be prepended')
+class ApplyLensCorrectionParameters(StackTransitionParameters):
     transform = Nested(TransformParameters)
     refId = Str(
         allow_none=True, required=True,
         description=('Reference ID to use when uploading transform to '
                      'render database (Not Implemented)'))
-    pool_size = Int(
-        required=False, default=1,
-        description="processes to spawn for parallelization")
-    close_stack = Boolean(
-        required=False, default=False,
-        description=("whether to set output stack to 'COMPLETE' "
-                     "upon completion"))
-    overwrite_zlayer = Boolean(
-        required=False, default=False,
-        description=("whether to remove the existing layer from the "
-                     "target stack before uploading."))
-
 
 
 class ApplyLensCorrectionOutput(DefaultSchema):
@@ -141,6 +120,7 @@ class ApplyLensCorrectionOutput(DefaultSchema):
                 description='stack to which transformed tiles were written')
     refId = Str(required=True,
                 description='unique identifier string used as reference ID')
+
 
 class LensCorrectionParameters(ArgSchema):
     manifest_path = InputFile(

--- a/rendermodules/materialize/schemas.py
+++ b/rendermodules/materialize/schemas.py
@@ -1,9 +1,9 @@
-
-from marshmallow import ValidationError, validates_schema, post_load, validate
 import argschema
-from rendermodules.module.schemas import RenderParameters, RenderClientParameters
+from rendermodules.module.schemas import (
+    RenderParameters, SparkParameters, MaterializedBoxParameters,
+    ZRangeParameters, RenderParametersRenderWebServiceParameters)
 from argschema.fields import (Str, OutputDir, Int, Boolean, Float,
-                              List, InputDir, InputFile, Dict, Nested)
+                              List, InputDir)
 
 
 class RenderSectionAtScaleParameters(RenderParameters):
@@ -54,96 +54,6 @@ class RenderSectionAtScaleOutput(argschema.schemas.DefaultSchema):
     temp_stack = Str(
         required=True,
         description='The temp stack that was used to generate the downsampled sections')
-
-
-
-class MaterializedBoxParameters(argschema.schemas.DefaultSchema):
-    stack = Str(required=True, description=(
-        "stack fromw which boxes will be materialized"))
-    rootDirectory = OutputDir(required=True, description=(
-        "directory in which materialization directory structure will be "
-        "created (structure is "
-        "<rootDirectory>/<project>/<stack>/<width>x<height>/<mipMapLevel>/<z>/<row>/<col>.<fmt>)"))
-    width = Int(required=True, description=(
-        "width of flat rectangular tiles to generate"))
-    height = Int(required=True, description=(
-        "height of flat rectangular tiles to generate"))
-    maxLevel = Int(required=False, default=0, description=(
-        "maximum mipMapLevel to generate."))
-    fmt = Str(required=False, validator=validate.OneOf(['PNG', 'TIF', 'JPG']),
-              description=("image format to generate mipmaps -- "
-                           "PNG if not specified"))
-    maxOverviewWidthAndHeight = Int(required=False, description=(
-        "maximum pixel size for width or height of overview image.  "
-        "If excluded or 0, no overview generated."))
-    skipInterpolation = Boolean(required=False, description=(
-        "whether to skip interpolation (e.g. DMG data)"))
-    binaryMask = Boolean(required=False, description=(
-        "whether to use binary mask (e.g. DMG data)"))
-    label = Boolean(required=False, description=(
-        "whether to generate single color tile labels rather "
-        "than actual images"))
-    createIGrid = Boolean(required=False, description=(
-        "whther to create an IGrid file"))
-    forceGeneration = Boolean(required=False, description=(
-        "whether to regenerate existing tiles"))
-    renderGroup = Int(required=False, description=(
-        "index (1-n) identifying coarse portion of layer to render"))
-    numberOfRenderGroups = Int(required=False, description=(
-        "used in conjunction with renderGroup, total number of groups "
-        "being used"))
-
-
-class ZRangeParameters(argschema.schemas.DefaultSchema):
-    # TODO how does this work with zValues?
-    minZ = Int(required=False, description=("minimum Z integer"))
-    maxZ = Int(required=False, description=("maximum Z integer"))
-
-
-class RenderWebServiceParameters(argschema.schemas.DefaultSchema):
-    baseDataUrl = Str(required=False, description=(
-        "api endpoint url e.g. http://<host>[:port]/render-ws/v1"))
-    owner = Str(required=False, description=("owner of target collection"))
-    project = Str(required=False, description=("project fo target collection"))
-
-
-class RenderParametersRenderWebServiceParameters(RenderWebServiceParameters):
-    render = Nested(
-        RenderClientParameters, only=['owner', 'project', 'host', 'port'],
-        required=False)
-
-    @post_load
-    def validate_options(self, data):
-        # fill in with render parameters if they are defined
-        if data.get('owner') is None:
-            data['owner'] = data['render']['owner']
-        if data.get('project') is None:
-            data['project'] = data['render']['project']
-        if data.get('baseDataUrl') is None:
-            data['baseDataUrl'] = '{host}{port}/render-ws/v1'.format(
-                host=(data['render']['host']
-                      if data['render']['host'].startswith(
-                      'http') else 'http://{}'.format(data['render']['host'])),
-                port=('' if data['render']['port'] is None else ':{}'.format(
-                      data['render']['port'])))
-
-
-class SparkParameters(argschema.schemas.DefaultSchema):
-    masterUrl = Str(required=True, description=(
-        "spark master url.  For local execution local[num_procs,num_retries]"))
-    jarfile = Str(required=True, description=(
-        "spark jar to call java spark command"))
-    className = Str(required=True, description=(
-        "spark class to call"))
-    driverMemory = Str(required=False, default='6g', description=(
-        "spark driver memory (important for local spark)"))
-    # memory = Str(required=False, defaut='6g', description=(""))
-    sparkhome = InputDir(required=True, description=(
-        "Spark home directory containing bin/spark_submit"))
-    spark_files = List(InputFile, required=False, description=(
-        "additional files for spark"))
-    spark_conf = Dict(required=False, description=(
-        "configuration dictionary for spark"))
 
 
 class MaterializeSectionsParameters(

--- a/rendermodules/module/render_module.py
+++ b/rendermodules/module/render_module.py
@@ -1,10 +1,18 @@
+#!/usr/bin/env python
+import subprocess
+import os
+
 import argschema
 import renderapi
-from rendermodules.module.schemas import RenderParameters
+from rendermodules.module.schemas import (
+    RenderParameters, InputStackParameters, OutputStackParameters,
+    SparkParameters)
+
 
 class RenderModuleException(Exception):
     """Base Exception class for render module"""
     pass
+
 
 class RenderModule(argschema.ArgSchemaParser):
     default_schema = RenderParameters
@@ -19,6 +27,140 @@ class RenderModule(argschema.ArgSchemaParser):
         super(RenderModule, self).__init__(
             schema_type=schema_type, *args, **kwargs)
         self.render = renderapi.render.connect(**self.args['render'])
+
+
+class StackInputModule(RenderModule):
+    default_schema = InputStackParameters
+
+    def __init__(self, *args, **kwargs):
+        super(StackInputModule, self).__init__(*args, **kwargs)
+        self.input_stack = self.args['input_stack']
+        self.zValues = self.args['zValues']
+
+
+class StackOutputModule(RenderModule):
+    default_schema = OutputStackParameters
+
+    def __init__(self, *args, **kwargs):
+        super(StackOutputModule, self).__init__(*args, **kwargs)
+        self.output_stack = self.args['output_stack']
+        self.zValues = self.args['zValues']
+        self.pool_size = self.args['pool_size']
+        self.close_stack = self.args['close_stack']
+        self.overwrite_zlayer = self.args['overwrite_zlayer']
+
+    def delete_zValues(self, zValues=None, output_stack=None, render=None):
+        zValues = self.zValues if zValues is None else zValues
+        output_stack = (self.output_stack if output_stack is None
+                        else output_stack)
+        render = self.render if render is None else render
+
+        for z in zValues:
+            try:
+                renderapi.stack.delete_section(
+                    output_stack, z, render=render)
+            except renderapi.errors.RenderError as e:
+                self.logger.error(e)
+
+    def output_tilespecs_to_stack(self, tilespecs, output_stack=None,
+                                  close_stack=None, overwrite_zlayer=None,
+                                  render=None, pool_size=None, **kwargs):
+        # TODO decorator to handle kwarg/attribute overrides?
+        output_stack = (self.output_stack if output_stack is None
+                        else output_stack)
+        render = self.render if render is None else render
+        close_stack = self.close_stack if close_stack is None else close_stack
+        pool_size = self.pool_size if pool_size is None else pool_size
+        overwrite_zlayer = (self.overwrite_zlayer if overwrite_zlayer is None
+                            else overwrite_zlayer)
+
+        renderapi.stack.create_stack(output_stack, render=render)
+        if output_stack not in render.run(
+                renderapi.render.get_stacks_by_owner_project):
+            # stack does not exist
+            render.run(renderapi.stack.create_stack,
+                       output_stack)
+
+        render.run(renderapi.stack.set_stack_state,
+                   output_stack, 'LOADING')
+
+        if overwrite_zlayer:
+            self.delete_zValues(output_stack=output_stack, render=render,
+                                **kwargs)
+        renderapi.client.import_tilespecs_parallel(
+            output_stack, tilespecs, pool_size=pool_size,
+            close_stack=close_stack, render=render)
+
+
+class StackTransitionModule(StackOutputModule, StackInputModule):
+    def __init__(self, *args, **kwargs):
+        super(StackTransitionModule, self).__init__(*args, **kwargs)
+
+
+class SparkModuleError(RenderModuleException):
+    """error thrown by rendermodules spark modules"""
+
+
+class SparkModule(argschema.ArgSchemaParser):
+    default_schema = SparkParameters
+
+    @staticmethod
+    def sanitize_cmd(cmd):
+        def jbool_str(c):
+            return str(c) if type(c) is not bool else "true" if c else "false"
+        if any([i is None for i in cmd]):
+            raise SparkModuleError(
+                'missing argument in command "{}"'.format(map(str, cmd)))
+        return map(jbool_str, cmd)
+
+    @staticmethod
+    def get_cmd_opt(v, flag=None):
+        return [] if v is None else [v] if flag is None else [flag, v]
+
+    @staticmethod
+    def get_flag_cmd(v, flag=None):
+        # for arity 0
+        return [flag] if v else []
+
+    @classmethod
+    def get_spark_call(cls, masterUrl=None, jarfile=None, className=None,
+                       driverMemory=None, memory=None, sparkhome=None,
+                       spark_files=None, spark_conf=None, **kwargs):
+        get_cmd_opt = cls.get_cmd_opt
+        sparksub = os.path.join(sparkhome, 'bin', 'spark-submit')
+
+        sparkfileargs = []
+        if spark_files is not None:
+            for sparkfile in spark_files:
+                sparkfileargs += ['--files', sparkfile]
+        sparkconfargs = []
+        if spark_conf is not None:
+            for key, value in spark_conf.items():
+                sparkconfargs += ['--conf', "{}='{}'".format(key, value)]
+
+        cmd = ([sparksub, '--master', masterUrl] +
+               get_cmd_opt(driverMemory, '--driver-memory') +
+               get_cmd_opt(memory, '--executor-memory') +
+               sparkfileargs +
+               sparkconfargs +
+               ['--class', className,
+               jarfile])
+        return cls.sanitize_cmd(cmd)
+
+    @classmethod
+    def get_args(cls, **kwargs):
+        """override to append to spark call"""
+        return cls.sanitize_cmd([])
+
+    @classmethod
+    def get_spark_command(cls, **kwargs):
+        c = cls.get_spark_call(**kwargs) + cls.get_args(**kwargs)
+        return c
+
+    def run_spark_command(self, **kwargs):
+        return subprocess.check_call(
+            self.get_spark_command(**self.args), **kwargs)
+
 
 if __name__ == '__main__':
     example_input = {

--- a/rendermodules/module/render_module.py
+++ b/rendermodules/module/render_module.py
@@ -37,6 +37,23 @@ class StackInputModule(RenderModule):
         self.input_stack = self.args['input_stack']
         self.zValues = self.args['zValues']
 
+    def get_inputstack_zs(self, input_stack=None, render=None, **kwargs):
+        input_stack = self.input_stack if input_stack is None else input_stack
+        render = self.render if render is None else render
+
+        return renderapi.stack.get_z_values_for_stack(
+            input_stack, render=render)
+
+    def get_overlapping_inputstack_zvalues(
+            self, input_stack=None, zValues=None,
+            render=None, **kwargs):
+        input_stack = self.input_stack if input_stack is None else input_stack
+        zValues = self.zValues if zValues is None else zValues
+        render = self.render if render is None else render
+
+        inputstack_zs = self.get_inputstack_zs(input_stack, render, **kwargs)
+        return list(set(zValues).intersection(set(inputstack_zs)))
+
 
 class StackOutputModule(RenderModule):
     default_schema = OutputStackParameters

--- a/rendermodules/module/schemas/__init__.py
+++ b/rendermodules/module/schemas/__init__.py
@@ -1,0 +1,4 @@
+from .schemas import *
+from .stack_schemas import *
+from .renderclient_schemas import *
+from .spark_schemas import *

--- a/rendermodules/module/schemas/renderclient_schemas.py
+++ b/rendermodules/module/schemas/renderclient_schemas.py
@@ -1,0 +1,191 @@
+import argschema
+from argschema.fields import (Str, OutputDir, Int, Boolean, Nested, Float,
+                              InputDir)
+
+from marshmallow import validate, post_load
+from .schemas import RenderClientParameters
+
+
+class MaterializedBoxParameters(argschema.schemas.DefaultSchema):
+    stack = Str(required=True, description=(
+        "stack fromw which boxes will be materialized"))
+    rootDirectory = OutputDir(required=True, description=(
+        "directory in which materialization directory structure will be "
+        "created (structure is "
+        "<rootDirectory>/<project>/<stack>/<width>x<height>/<mipMapLevel>/<z>/<row>/<col>.<fmt>)"))
+    width = Int(required=True, description=(
+        "width of flat rectangular tiles to generate"))
+    height = Int(required=True, description=(
+        "height of flat rectangular tiles to generate"))
+    maxLevel = Int(required=False, default=0, description=(
+        "maximum mipMapLevel to generate."))
+    fmt = Str(required=False, validator=validate.OneOf(['PNG', 'TIF', 'JPG']),
+              description=("image format to generate mipmaps -- "
+                           "PNG if not specified"))
+    maxOverviewWidthAndHeight = Int(required=False, description=(
+        "maximum pixel size for width or height of overview image.  "
+        "If excluded or 0, no overview generated."))
+    skipInterpolation = Boolean(required=False, description=(
+        "whether to skip interpolation (e.g. DMG data)"))
+    binaryMask = Boolean(required=False, description=(
+        "whether to use binary mask (e.g. DMG data)"))
+    label = Boolean(required=False, description=(
+        "whether to generate single color tile labels rather "
+        "than actual images"))
+    createIGrid = Boolean(required=False, description=(
+        "whther to create an IGrid file"))
+    forceGeneration = Boolean(required=False, description=(
+        "whether to regenerate existing tiles"))
+    renderGroup = Int(required=False, description=(
+        "index (1-n) identifying coarse portion of layer to render"))
+    numberOfRenderGroups = Int(required=False, description=(
+        "used in conjunction with renderGroup, total number of groups "
+        "being used"))
+
+
+class ZRangeParameters(argschema.schemas.DefaultSchema):
+    minZ = Int(required=False, description=("minimum Z integer"))
+    maxZ = Int(required=False, description=("maximum Z integer"))
+
+
+class WebServiceParameters(argschema.schemas.DefaultSchema):
+    baseDataUrl = Str(required=False, description=(
+        "api endpoint url e.g. http://<host>[:port]/render-ws/v1"))
+
+
+class RenderWebServiceParameters(WebServiceParameters):
+    owner = Str(required=False, description=("owner of target collection"))
+    project = Str(required=False, description=("project fo target collection"))
+
+
+class RenderParametersRenderWebServiceParameters(RenderWebServiceParameters):
+    render = Nested(
+        RenderClientParameters, only=['owner', 'project', 'host', 'port'],
+        required=False)
+
+    @post_load
+    def validate_options(self, data):
+        # fill in with render parameters if they are defined
+        if data.get('owner') is None:
+            data['owner'] = data['render']['owner']
+        if data.get('project') is None:
+            data['project'] = data['render']['project']
+        if data.get('baseDataUrl') is None:
+            data['baseDataUrl'] = '{host}{port}/render-ws/v1'.format(
+                host=(data['render']['host']
+                      if data['render']['host'].startswith(
+                      'http') else 'http://{}'.format(data['render']['host'])),
+                port=('' if data['render']['port'] is None else ':{}'.format(
+                      data['render']['port'])))
+
+
+class FeatureExtractionParameters(argschema.schemas.DefaultSchema):
+    SIFTfdSize = Int(required=False, description=(
+        "SIFT feature descriptor size -- samples per row and column. "
+        "8 if excluded or None"))
+    SIFTminScale = Float(required=False, description=(
+        "SIFT minimum scale -- "
+        "minSize * minScale < size < maxSize * maxScale. "
+        "0.5 if excluded or None"))
+    SIFTmaxScale = Float(required=False, description=(
+        "SIFT maximum scale -- "
+        "minSize * minScale < size < maxSize * maxScale. "
+        "0.85 if excluded or None"))
+    SIFTsteps = Int(required=False, description=(
+        "SIFT steps per scale octave. 3 if excluded or None"))
+
+
+class FeatureRenderClipParameters(argschema.schemas.DefaultSchema):
+    clipWidth = Int(required=False, description=(
+        "Full scale pixels to include in clipped rendering of "
+        "LEFT/RIGHT oriented tile pairs.  Will not LEFT/RIGHT clip if "
+        "excluded or None."))
+    clipHeight = Int(required=False, description=(
+        "Full scale pixels to include in clipped rendering of "
+        "TOP/BOTTOM oriented tile pairs.  Will not TOP/BOTTOM clip if "
+        "excluded or None."))
+
+
+class FeatureRenderParameters(argschema.schemas.DefaultSchema):
+    renderScale = Float(required=False, description=(
+        "Scale at which image tiles will be rendered. "
+        "1.0 (full scale) if excluded or None"))
+    renderWithFilter = Boolean(required=False, description=(
+        "Render tiles using default filtering "
+        "(0 and 255 pixel values replaced with integer in U(64, 191), "
+        "followed by default NormalizeLocalContrast). "
+        "True if excluded or None"))
+    renderWithoutMask = Boolean(required=False, description=(
+        "Render tiles without mipMapLevel masks. True if excluded or None"))
+    renderFullScaleWidth = Int(required=False, description=(
+        "Full scale width for all rendered tiles"))
+    renderFullScaleHeight = Int(required=False, description=(
+        "Full scale height for all rendered tiles"))
+    fillWithNoise = Boolean(required=False, description=(
+        "Fill each canvas image with noise prior to rendering. "
+        "True if excluded or None"))
+
+
+class FeatureStorageParameters(argschema.schemas.DefaultSchema):
+    # TODO is this inputdir or outputdir?
+    rootFeatureDirectory = Str(required=False, description=(
+        "Root directory for saved feature lists. "
+        "Features extracted from dynamically rendered canvases "
+        "if excluded or None."))
+    requireStoredFeature = Boolean(required=False, description=(
+        "Whether to throw an exception in case features stored in "
+        "rootFeatureDirectory cannot be found. "
+        "Missing features are extracted from dynamically rendered canvases "
+        "if excluded or None"))
+    maxFeatureCacheGb = Int(required=False, description=(
+        "Maximum size of feature cache, in GB. 2GB if excluded or None"))
+
+
+class MatchDerivationParameters(argschema.schemas.DefaultSchema):
+    matchRod = Float(required=False, description=(
+        "Ratio of first to second nearest neighbors used as a cutoff in "
+        "matching features. 0.92 if excluded or None"))
+    matchModelType = Str(required=False, validator=validate.OneOf([
+        "AFFINE", "RIGID", "SIMILARITY", "TRANSLATION"]), description=(
+        "Model to match for RANSAC filtering. 'AFFINE' if excluded or None"))
+    matchIterations = Int(required=False, description=(
+        "RANSAC filter iterations.  1000 if excluded or None"))
+    matchMaxEpsilon = Float(required=False, description=(
+        ""))
+    matchMinInlierRatio = Float(required=False, description=(
+        "Minimal ratio of inliers to candidates for successful "
+        "RANSAC filtering.  0.0 if excluded or None"))
+    matchMinNumInliers = Int(required=False, description=(
+        "Minimum absolute number of inliers for successful RANSAC filtering. "
+        "4 if excluded or None"))
+    matchMaxNumInliers = Int(required=False, description=(
+        "Maximum absolute number of inliers allowed after RANSAC filtering. "
+        "unlimited if excluded or None"))
+    matchMaxTrust = Float(required=False, description=(
+        "Maximum trust for filtering such that candidates with cost larger "
+        "than matchMaxTrust * median cost are rejected. "
+        "3.0 if excluded or None"))
+
+
+class MatchWebServiceParameters(WebServiceParameters):
+    owner = Str(required=False, description=("owner of match collection"))
+    collection = Str(required=False, description=("match collection name"))
+
+
+class RenderParametersMatchWebServiceParameters(MatchWebServiceParameters):
+    render = Nested(
+        RenderClientParameters, only=['owner', 'host', 'port'],
+        required=False)
+
+    @post_load
+    def validate_options(self, data):
+        # fill in with render parameters if they are defined
+        if data.get('owner') is None:
+            data['owner'] = data['render']['owner']
+        if data.get('baseDataUrl') is None:
+            data['baseDataUrl'] = '{host}{port}/render-ws/v1'.format(
+                host=(data['render']['host']
+                      if data['render']['host'].startswith(
+                      'http') else 'http://{}'.format(data['render']['host'])),
+                port=('' if data['render']['port'] is None else ':{}'.format(
+                      data['render']['port'])))

--- a/rendermodules/module/schemas/schemas.py
+++ b/rendermodules/module/schemas/schemas.py
@@ -27,7 +27,8 @@ class RenderParameters(argschema.ArgSchema):
 class TemplateParameters(RenderParameters):
     example = argschema.fields.Str(required=True,
                                    description='an example')
-    default_val = argschema.fields.Str(required=False, default="a default value",
+    default_val = argschema.fields.Str(required=False,
+                                       default="a default value",
                                        description='an example with a default')
 
 

--- a/rendermodules/module/schemas/spark_schemas.py
+++ b/rendermodules/module/schemas/spark_schemas.py
@@ -1,0 +1,26 @@
+import argschema
+from argschema.fields import Str, InputDir, List, InputFile, Dict
+
+
+class SparkOptions(argschema.schemas.DefaultSchema):
+    jarfile = Str(required=True, description=(
+        "spark jar to call java spark command"))
+    className = Str(required=True, description=(
+        "spark class to call"))
+    driverMemory = Str(required=False, default='6g', description=(
+        "spark driver memory (important for local spark)"))
+    memory = Str(
+        required=False,
+        description="Memory required for spark job")
+    sparkhome = InputDir(required=True, description=(
+        "Spark home directory containing bin/spark_submit"))
+    spark_files = List(InputFile, required=False, description=(
+        "list of spark files to add to the spark submit command"))
+    spark_conf = Dict(required=False, description=(
+        "dictionary of key value pairs to add to spark_submit "
+        "as --conf key=value"))
+
+
+class SparkParameters(SparkOptions):
+    masterUrl = Str(required=True, description=(
+        "spark master url.  For local execution local[num_procs,num_retries]"))

--- a/rendermodules/module/schemas/stack_schemas.py
+++ b/rendermodules/module/schemas/stack_schemas.py
@@ -44,7 +44,6 @@ class ZValueParameters(  # argschema.schemas.DefaultSchema,
         return self._generate_zValues(data)
 
     def _generate_zValues(self, data):
-        print data
         if 'zValues' in data:
             return
         elif 'z' in data:

--- a/rendermodules/module/schemas/stack_schemas.py
+++ b/rendermodules/module/schemas/stack_schemas.py
@@ -1,0 +1,130 @@
+import warnings
+
+import argschema
+from marshmallow import ValidationError, validate, post_load, pre_load
+from .schemas import RenderParameters
+
+
+class OverridableParameterSchema(argschema.schemas.DefaultSchema):
+    @pre_load
+    def override_input(self, data):
+        return self._override_input(data)
+
+    def _override_input(self, data):
+        pass
+
+    @staticmethod
+    def fix_badkey(data, badkey, goodkey):
+        if badkey in data:
+            warnings.warn(
+                "{b} variable has been deprecated. Will try to fill in "
+                "{g} if empty.".format(b=badkey, g=goodkey),
+                DeprecationWarning)
+            data[goodkey] = (
+                data[goodkey] if (goodkey in data) else data[badkey])
+
+
+class ProcessPoolParameters(argschema.schemas.DefaultSchema):
+    pool_size = argschema.fields.Int(required=False, default=1)
+
+
+class ZValueParameters(  # argschema.schemas.DefaultSchema,
+                       OverridableParameterSchema):
+    """template schema which interprets z values on which to act
+    assumes a hierarchy such that minZ, maxZ are
+    superceded by z which is superceded by zValues.
+    """
+    minZ = argschema.fields.Int(required=False)
+    maxZ = argschema.fields.Int(required=False)
+    z = argschema.fields.Int(required=False)
+    zValues = argschema.fields.List(argschema.fields.Int, required=False)
+
+    @post_load
+    def generate_zValues(self, data):
+        return self._generate_zValues(data)
+
+    def _generate_zValues(self, data):
+        print data
+        if 'zValues' in data:
+            return
+        elif 'z' in data:
+            data['zValues'] = [data['z']]
+        elif ('minZ' in data) and ('maxZ' in data):
+            data['zValues'] = range(data['minZ'], data['maxZ'] + 1)
+        else:
+            raise ValidationError("no z values specified")
+
+    def _override_input(self, data):
+        super(ZValueParameters, self)._override_input(data)
+        self.fix_badkey(data, 'z_index', 'z')
+        self.fix_badkey(data, 'zstart', 'minZ')
+        self.fix_badkey(data, 'zend', 'maxZ')
+        self.fix_badkey(data, 'zs', 'zValues')
+
+
+class RenderMipMapPathBuilder(argschema.schemas.DefaultSchema):
+    rootPath = argschema.fields.Str(required=False)
+    numberOfLevels = argschema.fields.Int(required=False)
+    extension = argschema.fields.Str(
+        required=False, validator=validate.OneOf(['png', 'jpg', 'tif']))
+
+
+class RenderCycle(argschema.schemas.DefaultSchema):
+    number = argschema.fields.Int(required=False)
+    stepNumber = argschema.fields.Int(required=False)
+
+
+class RenderStackVersion(argschema.schemas.DefaultSchema):
+    createTimestamp = argschema.fields.Str(required=False)  # TODO DateTime
+    versionNotes = argschema.fields.Str(required=False)
+    cycleNumber = argschema.fields.Int(required=False)
+    cycleStepNumber = argschema.fields.Int(required=False)
+    stackResolutionX = argschema.fields.Float(required=False)
+    stackResolutionY = argschema.fields.Float(required=False)
+    stackResolutionZ = argschema.fields.Float(required=False)
+    materializedBoxRootPath = argschema.fields.Str(required=False)
+    mipmapPathBuilder = argschema.fields.Nested(RenderMipMapPathBuilder,
+                                                required=False)
+    cycle = argschema.fields.Nested(RenderCycle, required=False)
+    stackResolutionValues = argschema.fields.List(argschema.fields.Int,
+                                                  required=False)
+
+
+class OutputStackParameters(RenderParameters, ZValueParameters,
+                            ProcessPoolParameters, OverridableParameterSchema):
+    """template schema for writing tilespecs to an output stack"""
+    output_stack = argschema.fields.Str(required=True)
+    close_stack = argschema.fields.Boolean(required=False, default=False)
+    overwrite_zlayer = argschema.fields.Boolean(required=False, default=False)
+    output_stackVersion = argschema.fields.Nested(
+        RenderStackVersion, required=False)
+
+    def _override_input(self, data):
+        super(OutputStackParameters, self)._override_input(data)
+        self.fix_badkey(data, 'stack', 'output_stack')
+        self.fix_badkey(data, 'outputStack', 'output_stack')
+
+
+class InputStackParameters(RenderParameters, ZValueParameters,
+                           OverridableParameterSchema):
+    """template schema for schemas which take input from a stack
+    """
+    input_stack = argschema.fields.Str(required=True)
+
+    def _override_input(self, data):
+        super(InputStackParameters, self)._override_input(data)
+        self.fix_badkey(data, 'stack', 'input_stack')
+        self.fix_badkey(data, 'inputStack', 'input_stack')
+
+
+class StackTransitionParameters(OutputStackParameters, InputStackParameters):
+    """template schema for schemas which take input from one stack, perform
+    (mostly render-python based) operations on tiles from that stack,
+    and output tiles to another stack.
+    """
+    def _override_input(self, data):
+        if 'stack' in data:
+            raise ValidationError(
+                "key 'stack' is ambiguous please specify "
+                "input_stack or output_stack")
+        super(StackTransitionParameters, self)._override_input(data)

--- a/rendermodules/module/schemas/stack_schemas.py
+++ b/rendermodules/module/schemas/stack_schemas.py
@@ -55,6 +55,8 @@ class ZValueParameters(  # argschema.schemas.DefaultSchema,
 
     def _override_input(self, data):
         super(ZValueParameters, self)._override_input(data)
+        # DEPRECATED
+        # the following overrides should be removed in future versions
         self.fix_badkey(data, 'z_index', 'z')
         self.fix_badkey(data, 'zstart', 'minZ')
         self.fix_badkey(data, 'zend', 'maxZ')
@@ -100,6 +102,8 @@ class OutputStackParameters(RenderParameters, ZValueParameters,
 
     def _override_input(self, data):
         super(OutputStackParameters, self)._override_input(data)
+        # DEPRECATED
+        # the following overrides should be removed in future versions
         self.fix_badkey(data, 'stack', 'output_stack')
         self.fix_badkey(data, 'outputStack', 'output_stack')
 
@@ -112,6 +116,8 @@ class InputStackParameters(RenderParameters, ZValueParameters,
 
     def _override_input(self, data):
         super(InputStackParameters, self)._override_input(data)
+        # DEPRECATED
+        # the following overrides should be removed in future versions
         self.fix_badkey(data, 'stack', 'input_stack')
         self.fix_badkey(data, 'inputStack', 'input_stack')
 

--- a/rendermodules/pointmatch/schemas.py
+++ b/rendermodules/pointmatch/schemas.py
@@ -1,8 +1,13 @@
-from argschema.fields import Bool, Float, Int, Nested, Str, InputDir, InputFile, OutputDir, List, Dict
+from argschema.fields import (Bool, Float, Int, Nested, Str, InputDir,
+                              InputFile, OutputDir)
 from argschema.schemas import DefaultSchema
 import marshmallow as mm
-from marshmallow import ValidationError, validates_schema, post_load
-from rendermodules.module.schemas import RenderParameters
+import argschema
+from marshmallow import  post_load
+from rendermodules.module.schemas import (
+    RenderParameters, FeatureExtractionParameters, FeatureRenderParameters,
+    FeatureStorageParameters, MatchDerivationParameters,
+    RenderParametersMatchWebServiceParameters, SparkOptions, SparkParameters)
 
 
 class TilePairClientOutputParameters(DefaultSchema):
@@ -67,124 +72,18 @@ class TilePairClientParameters(RenderParameters):
 
 
 
-class SIFTPointMatchParameters(RenderParameters):
-    jarfile = Str(
-        required=True,
-        description="Full path to the spark point match client jar file")
-    className = Str(
-        required=True,
-        description="Class name of java class")
-    owner = Str(
-        required=False,
-        default=None,
-        missing=None,
-        description="Point match collection owner")
-    collection = Str(
-        required=True,
-        description="Name of point match collection to save point matches")
-    baseDataUrl = Str(
-        required=False,
-        default=None,
-        missing=None,
-        description="Base data URL of render")
-    pairJson = Str(
-        required=True,
-        description="Full path to the input tile pair json file")
-    SIFTfdSize = Int(
-        required=False,
-        default=8,
-        missing=8,
-        description="SIFT feature descriptor size: how many samples per row and column")
-    SIFTsteps = Int(
-        required=False,
-        default=3,
-        missing=3,
-        description="SIFT steps per scale octave")
-    matchMaxEpsilon = Float(
-        required=False,
-        default=20.0,
-        missing=20.0,
-        description="Minimal allowed transfer error for match filtering")
-    maxFeatureCacheGb = Int(
-        required=False,
-        default=15,
-        missing=15,
-        description="Maximum memory (in Gb) for caching SIFT features")
-    SIFTminScale = Float(
-        required=False,
-        default=0.38,
-        missing=0.38,
-        description="SIFT minimum scale: minSize * minScale < size < maxSize * maxScale")
-    SIFTmaxScale = Float(
-        required=False,
-        default=0.82,
-        missing=0.82,
-        description="SIFT maximum scale: minSize * minScale < size < maxSize * maxScale")
-    renderScale = Float(
-        required=False,
-        default=0.3,
-        missing=0.3,
-        description="Render canvases at this scale")
-    matchRod = Float(
-        required=False,
-        default=0.92,
-        missing=0.92,
-        description="Ratio of distances for matches")
-    matchMinInlierRatio = Float(
-        required=False,
-        default=0.0,
-        missing=0.0,
-        description="Minimal ratio of inliers to candidates for match filtering")
-    matchMinNumInliers = Int(
-        required=False,
-        default=8,
-        missing=8,
-        description="Minimal absolute number of inliers for match filtering")
-    matchMaxNumInliers = Int(
-        required=False,
-        default=200,
-        description="Maximum number of inliers for match filtering")
-    clipWidth = Int(
-        required=False,
-        description = "Number of pixels to clip left right when doing montaging (default no clipping)"
-    )
-    clipHeight = Int(
-        required=False,
-        description= "Number of pixels to clip top/bottom when doing montaging (default no clipping)"
-    )
-    @post_load
-    def validate_options(self, data):
-        if data['owner'] is None:
-            data['owner'] = data['render']['owner']
-        if data['baseDataUrl'] is None:
-            data['baseDataUrl'] = 'http://' + data['render']['host'] + ":" + str(data['render']['port']) + "/render-ws/v1"
+class SIFTPointMatchParameters(argschema.ArgSchema,
+        FeatureExtractionParameters, FeatureRenderParameters,
+        FeatureStorageParameters, MatchDerivationParameters,
+        RenderParametersMatchWebServiceParameters):
+    pairJson = InputFile(required=True, description=(
+        "JSON file where tile pairs are stored (.json, .gz, .zip)"))
 
-class PointMatchClientParametersSpark(SIFTPointMatchParameters):
-    memory = Str(
-        required=False,
-        default='120g',
-        missing='120g',
-        description="Memory required for spark job")
-    driverMemory = Str(
-        required=False,
-        default='6g',
-        missing='6g',
-        description="memory required for spark driver"
-    )
-    masterUrl = Str(
-        required=True,
-        description="Master URL for spark cluster")
-    sparkhome = InputDir(
-        required=True,
-        default="/allen/aibs/shared/image_processing/volume_assembly/utils/spark",
-        missing="/allen/aibs/shared/image_processing/volume_assembly/utils/spark",
-        description="Path to the spark home directory")
-    spark_files = List( Str,
-        required=False,
-        description = "list of spark files to add to the spark submit command")
-    spark_conf = Dict(
-        required=False,
-        description= "dictionary of key value pairs to add to spark_submit as --conf key=value")
+
+class PointMatchClientParametersSpark(SparkParameters,
+                                      SIFTPointMatchParameters):
+    pass
+
 
 class CollectionId(mm.Schema):
     owner = Str(required=True,
@@ -200,7 +99,8 @@ class PointMatchClientOutputSchema(mm.Schema):
         required=True,
         description = "number of tile pairs in collection")
 
-class PointMatchClientParametersQsub(SIFTPointMatchParameters):
+class PointMatchClientParametersQsub(
+        RenderParameters, SIFTPointMatchParameters, SparkOptions):
     sparkhome = InputDir(
         required=True,
         default="/allen/aibs/pipeline/image_processing/volume_assembly/utils/spark",


### PR DESCRIPTION
refactor addressing #74 and #71

Adds schemas and argschemaparser classes to rendermodules.module which facilitate common stack operations and spark use cases to allow for code reuse.

Also important -- most tests now create new dictionary objects via copy or dict() prior to running tests as pre_load operations in schemas were changing the dictionary objects being used by other tests.