### PR TITLE
Redirect mipmaps

### DIFF
--- a/integration_tests/test_consolidate.py
+++ b/integration_tests/test_consolidate.py
@@ -1,11 +1,17 @@
-import renderapi
-from rendermodules.stack.consolidate_transforms import ConsolidateTransforms, process_z, consolidate_transforms
-from rendermodules.module.render_module import RenderModuleException
-from test_data import render_params, cons_ex_tilespec_json, cons_ex_transform_json
-import pytest
-import numpy as np
 import json
 import logging
+import os
+import urllib
+import urlparse
+import pytest
+import numpy as np
+
+import renderapi
+
+from test_data import render_params, cons_ex_tilespec_json, cons_ex_transform_json
+from rendermodules.module.render_module import RenderModuleException
+from rendermodules.stack.consolidate_transforms import ConsolidateTransforms, process_z, consolidate_transforms
+from rendermodules.stack import redirect_mipmaps
 
 EPSILON = .001
 render_params['project'] = "consolidate_test"
@@ -103,3 +109,32 @@ def test_consolidate_transforms_function(render,test_stack):
 
     with pytest.raises(RenderModuleException) as e:
         new_tforms=consolidate_transforms(tile0.tforms)
+
+
+def test_redirect_mipMapLevels(render, test_stack, tmpdir):
+    output_stack = "redirect_mipmaps_test"
+    out_fn = 'redirectmipmapsout.json'
+
+    z = renderapi.stack.get_z_values_for_stack(test_stack, render=render)[0]
+    input_d = dict(redirect_mipmaps.example_input, **{
+        "input_stack": test_stack,
+        "output_stack": output_stack,
+        "render": render.DEFAULT_KWARGS,
+        "z": z,
+        "new_mipmap_directories": [{
+            "level": 0,
+            "directory": str(tmpdir)
+        }]
+    })
+
+    mod = redirect_mipmaps.RedirectMipMapsModule(
+        input_data=input_d, args=['--output_json', out_fn])
+    mod.run()
+
+    modified_tspecs = renderapi.tilespec.get_tile_specs_from_z(
+        output_stack, z, render=render)
+
+    assert all([os.path.abspath(urllib.unquote(urlparse.urlparse(
+        ts.ip.get(0)['imageUrl']).path)).startswith(
+            os.path.abspath(str(tmpdir)))
+                for ts in modified_tspecs])

--- a/rendermodules/stack/redirect_mipmaps.py
+++ b/rendermodules/stack/redirect_mipmaps.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+"""
+change storage directory of imageUrl in a given mipMapLevel
+"""
+import copy
+import os
+import pathlib
+
+import renderapi
+
+from rendermodules.module.render_module import StackTransitionModule
+from rendermodules.stack.schemas import (RedirectMipMapsParameters,
+                                         RedirectMipMapsOutput)
+
+example_input = {
+    "input_stack": "TEST_IMPORT_FROMMD",
+    "output_stack": "TEST_redmml",
+    "pool_size": 10,
+    "render": {
+        "host": "em-131fs",
+        "port": 8080,
+        "owner": "russelt",
+        "project": "RENDERAPI_TEST",
+        "client_scripts": "/allen/aibs/pipeline/image_processing/volume_assembly/render-jars/production/scripts/"
+    },
+    "close_stack": False,
+    "overwrite_zlayer": True,
+    "z": 1,
+    "new_mipmap_directories": [{
+        "level": 0,
+        "directory": "/allen/programs/celltypes/production/"
+        }]
+}
+
+
+class RedirectMipMapsModule(StackTransitionModule):
+    default_schema = RedirectMipMapsParameters
+    default_output_schema = RedirectMipMapsOutput
+
+    @staticmethod
+    def get_replacement_mmL(mmL, d):
+        return renderapi.image_pyramid.MipMapLevel(
+            mmL.level,
+            pathlib.Path(os.path.join(
+                d, os.path.basename(mmL.imageUrl))).as_uri(),
+            mmL.maskUrl)
+
+    def run(self):
+        mmL_d_map = {i['level']: i['directory']
+                     for i in
+                     self.args['new_mipmap_directories']}
+        zs = self.get_overlapping_inputstack_zvalues()
+        for z in zs:
+            tspecs = renderapi.tilespec.get_tile_specs_from_z(
+                self.input_stack, z, render=self.render)
+
+            new_tspecs = []
+            for ts in tspecs:
+                ts_new = copy.copy(ts)
+                ts_new.ip.mipMapLevels = [
+                    (mmL if (mmL.level not in mmL_d_map)
+                     else self.get_replacement_mmL(mmL, mmL_d_map[mmL.level]))
+                    for mmL in ts_new.ip.mipMapLevels]
+                new_tspecs.append(ts_new)
+
+            self.output_tilespecs_to_stack(new_tspecs, zValues=[z])
+
+        self.output({
+            "zValues": zs,
+            "output_stack": self.output_stack
+            })
+
+
+
+if __name__ == "__main__":
+    mod = RedirectMipMapsModule(input_data=example_input)
+    mod.run()

--- a/rendermodules/stack/schemas.py
+++ b/rendermodules/stack/schemas.py
@@ -1,5 +1,7 @@
-from rendermodules.module.schemas import RenderParameters
-from argschema.fields import Str, Int, Slice, Float, Boolean
+from rendermodules.module.schemas import (RenderParameters,
+                                          StackTransitionParameters)
+from argschema.fields import (Str, Int, Slice, Float, Boolean,
+                              List, Nested, InputDir)
 from argschema.schemas import DefaultSchema
 
 class ConsolidateTransformsParameters(RenderParameters):
@@ -30,3 +32,20 @@ class ConsolidateTransformsParameters(RenderParameters):
 class ConsolidateTransformsOutputParameters(DefaultSchema):
     output_stack = Str(required=True, description="name of output stack")
     numZ = Int(required=True, description="Number of z values processed")
+
+
+class MipMapDirectories(DefaultSchema):
+    level = Int(required=True, description=(
+        "mipMapLevel for which parent directory will be changed"))
+    directory = InputDir(required=True, description=(
+        "directory where relocated mipmaps are found."))
+
+
+class RedirectMipMapsParameters(StackTransitionParameters):
+    new_mipmap_directories = Nested(
+        MipMapDirectories, required=True, many=True)
+
+
+class RedirectMipMapsOutput(DefaultSchema):
+    zValues = List(Int, required=True)
+    output_stack = Str(required=True)


### PR DESCRIPTION
This is high-priority to get into our deployment.

simply points mipMapLevel basenames to a new directory.