### PR TITLE
downsample makestack

### DIFF
--- a/integration_tests/test_dataimport.py
+++ b/integration_tests/test_dataimport.py
@@ -1,13 +1,13 @@
 import json
-import pytest
 import urllib
 import urlparse
 import tempfile
 import logging
-from PIL import Image
+import pytest
 import renderapi
-from rendermodules.module.render_module import RenderModuleException
 import marshmallow as mm
+from rendermodules.utilities.pillow_utils import Image
+from rendermodules.module.render_module import RenderModuleException
 from rendermodules.dataimport import generate_EM_tilespecs_from_metafile
 from rendermodules.dataimport import generate_mipmaps
 from rendermodules.dataimport import apply_mipmaps_to_render

--- a/integration_tests/test_materialize.py
+++ b/integration_tests/test_materialize.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python
 '''
 '''
-import json
 import os
 import imghdr
 import copy
 
 import pytest
 
-from PIL import Image
 
 import renderapi
+from rendermodules.utilities.pillow_utils import Image
 from rendermodules.materialize import materialize_sections
 from test_data import (render_params, MATERIALIZE_BOX_JSON)
 

--- a/rendermodules/dataimport/create_mipmaps.py
+++ b/rendermodules/dataimport/create_mipmaps.py
@@ -1,9 +1,9 @@
 import os
 
 import numpy
-from PIL import Image
 from skimage.measure import block_reduce
 
+from rendermodules.utilities.pillow_utils import Image
 from rendermodules.module.render_module import RenderModuleException
 
 

--- a/rendermodules/dataimport/schemas.py
+++ b/rendermodules/dataimport/schemas.py
@@ -129,6 +129,19 @@ class MakeMontageScapeSectionStackParameters(OutputStackParameters):
     scale = Float(
         required=True,
         metadata={'description':'scale of montage scapes'})
+    doFilter = Boolean(required=False, default=True, description=(
+        "whether to apply default filtering when generating "
+        "missing downsamples"))
+    level = Int(required=False, default=1, description=(
+        "integer mipMapLevel used to generate missing downsamples"))
+    fillWithNoise = Boolean(required=False, default=False, description=(
+        "Whether to fill the background pixels with noise when "
+        "generating missing downsamples"))
+    memGB_materialize = Str(required=False, default='12G', description=(
+        "Java heap size in GB for materialization"))
+    pool_size_materialize = Int(required=False, default=1, description=(
+        "number of processes to generate missing downsamples"))
+
 
     @post_load
     def validate_data(self, data):

--- a/rendermodules/materialize/render_downsample_sections.py
+++ b/rendermodules/materialize/render_downsample_sections.py
@@ -1,11 +1,9 @@
 from functools import partial
-import random
 import time
-import json
 import numpy as np
 import renderapi
-import tempfile
-from rendermodules.materialize.schemas import RenderSectionAtScaleParameters, RenderSectionAtScaleOutput
+from rendermodules.materialize.schemas import (RenderSectionAtScaleParameters,
+                                               RenderSectionAtScaleOutput)
 from ..module.render_module import RenderModule, RenderModuleException
 
 
@@ -41,42 +39,86 @@ example = {
     "maxZ": 1022
 }
 
+
 def check_stack_for_mipmaps(render, input_stack, zvalues):
     # this function checks for the mipmaplevels for the first section in the stack
     # Assumes that all the sections in the stack has mipmaps stored if the first section has mipmaps
-    
-    #z = random.choice(zvalues)
-    z = zvalues [0]
-    tilespecs = render.run(renderapi.tilespec.get_tile_specs_from_z,
-                            input_stack,
-                            z)
-    for ts in tilespecs:
-        m = ts.to_dict()
-        m['mipmapLevels'] = dict(m['mipmapLevels'])
-        if len(m['mipmapLevels'].keys()) > 1:
-            return True
 
+    # z = random.choice(zvalues)
+    z = zvalues[0]
+    tilespecs = render.run(renderapi.tilespec.get_tile_specs_from_z,
+                           input_stack, z)
+    for ts in tilespecs:
+        if len(ts.ip.mipMapLevels) > 1:
+            return True
     return False
+
 
 def create_tilespecs_without_mipmaps(render, montage_stack, level, z):
     ts = render.run(renderapi.tilespec.get_tile_specs_from_z, montage_stack, z)
-    tilespecs = []
     for t in ts:
-        m = t.to_dict()
-        m['mipmapLevels'] = dict(m['mipmapLevels'])
-        [m['mipmapLevels'].pop(k, 0) for k in m['mipmapLevels'].keys() if k != level]
-        tilespecs.append(m)
-    tempjson = tempfile.NamedTemporaryFile(suffix=".json", mode='w', delete=True)
-    tempjson.close()
-    with open(tempjson.name, 'w') as f:
-        json.dump(tilespecs, f, indent=4)
-        f.close()
-    return tempjson.name
+        t.ip.mipMapLevels = [mmL for mmL in t.ip.mipMapLevels
+                             if mmL.level == level]
+    tempjson = renderapi.utils.renderdump_temp(ts, indent=4)
+    return tempjson
 
 
 class RenderSectionAtScale(RenderModule):
     default_schema = RenderSectionAtScaleParameters
     default_output_schema = RenderSectionAtScaleOutput
+
+    @classmethod
+    def downsample_specific_mipmapLevel(
+            cls, zvalues, input_stack=None, level=1, pool_size=None,
+            image_directory=None, scale=None, imgformat=None, doFilter=None,
+            fillWithNoise=None, render=None, **kwargs):
+        stack_has_mipmaps = check_stack_for_mipmaps(
+            render, input_stack, zvalues)
+
+        ds_source = input_stack
+        # check if there are mipmaps in this stack
+        if stack_has_mipmaps:
+            print("stack has mipmaps")
+            # clone the input stack to a temporary one with level 1 mipmap alone
+            temp_no_mipmap_stack = "{}_no_mml_t{}".format(
+                input_stack, time.strftime("%m%d%y_%H%M%S"))
+
+            mypartial = partial(create_tilespecs_without_mipmaps,
+                                render, input_stack, level)
+
+            with renderapi.client.WithPool(pool_size) as pool:
+                jsonfiles = pool.map(mypartial, zvalues)
+
+            # create stack - overwrites existing one
+            render.run(renderapi.stack.create_stack, temp_no_mipmap_stack)
+
+            # set stack state to LOADING
+            render.run(renderapi.stack.set_stack_state,
+                       temp_no_mipmap_stack, state='LOADING')
+
+            # import json files into temp_no_mipmap_stack
+            # this also sets the stack's state to COMPLETE
+            render.run(renderapi.client.import_jsonfiles_parallel,
+                       temp_no_mipmap_stack,
+                       jsonfiles,
+                       poolsize=pool_size,
+                       close_stack=True)
+            ds_source = temp_no_mipmap_stack
+
+        render.run(renderapi.client.renderSectionClient,
+                   ds_source,
+                   image_directory,
+                   zvalues,
+                   scale=scale,
+                   format=imgformat,
+                   doFilter=doFilter,
+                   fillWithNoise=fillWithNoise)
+
+        if stack_has_mipmaps:
+            # delete the temp stack
+            render.run(renderapi.stack.delete_stack,
+                       temp_no_mipmap_stack)
+        return ds_source
 
     def run(self):
 
@@ -88,73 +130,25 @@ class RenderSectionAtScale(RenderModule):
             self.args['minZ'] = min(zvalues1)
             self.args['maxZ'] = max(zvalues1)
         elif self.args['minZ'] > self.args['maxZ']:
-            raise RenderModuleException('Invalid Z range: {} > {}'.format(self.args['minZ'], self.args['maxZ']))
-        
+            raise RenderModuleException('Invalid Z range: {} > {}'.format(
+                self.args['minZ'], self.args['maxZ']))
+
         zvalues1 = np.array(zvalues1)
         zrange = range(int(self.args['minZ']), int(self.args['maxZ'])+1)
         zvalues = list(set(zvalues1).intersection(set(zrange)))
 
         if not zvalues:
-            raise RenderModuleException('No valid zvalues found in stack for given range {} - {}'.format(self.args['minZ'], self.args['maxZ']))
+            raise RenderModuleException(
+                'No valid zvalues found in stack for '
+                'given range {} - {}'.format(
+                    self.args['minZ'], self.args['maxZ']))
 
-        self.args['temp_stack'] = self.args['input_stack']
+        self.args['temp_stack'] = self.downsample_specific_mipmapLevel(
+            zvalues, **dict(self.args, **{'render': self.render}))
 
-        #intz = [int(z) for z in zvalues]
-
-        stack_has_mipmaps = check_stack_for_mipmaps(self.render, self.args['input_stack'], zvalues)
-
-        # check if there are mipmaps in this stack
-        if stack_has_mipmaps:
-            print("stack has mipmaps")
-            # clone the input stack to a temporary one with level 1 mipmap alone
-            temp_no_mipmap_stack = "{}_no_mml_t{}".format(self.args['input_stack'], time.strftime("%m%d%y_%H%M%S"))
-
-            # set level of mipmap to retain as 1 (level 1)
-            level = 1
-            mypartial = partial(create_tilespecs_without_mipmaps,
-                                self.render,
-                                self.args['input_stack'],
-                                level)
-
-            with renderapi.client.WithPool(self.args['pool_size']) as pool:
-                jsonfiles = pool.map(mypartial, zvalues)
-
-            # set temp_stack as temp_no_mipmap_stack
-            self.args['temp_stack'] = temp_no_mipmap_stack
-
-            # create stack - overwrites existing one
-            self.render.run(renderapi.stack.create_stack,
-                        self.args['temp_stack'])
-
-            # set stack state to LOADING
-            self.render.run(renderapi.stack.set_stack_state,
-                        self.args['temp_stack'],
-                        state='LOADING')
-
-            # import json files into temp_no_mipmap_stack
-            # this also sets the stack's state to COMPLETE
-            self.render.run(renderapi.client.import_jsonfiles_parallel,
-                        self.args['temp_stack'],
-                        jsonfiles,
-                        poolsize=self.args['pool_size'],
-                        close_stack=True)
-
-
-        self.render.run(renderapi.client.renderSectionClient,
-                        self.args['temp_stack'],
-                        self.args['image_directory'],
-                        zvalues,
-                        scale=self.args['scale'],
-                        format=self.args['imgformat'],
-                        doFilter=self.args['doFilter'],
-                        fillWithNoise=self.args['fillWithNoise'])
-        
-        if stack_has_mipmaps:
-            # delete the temp stack
-            self.render.run(renderapi.stack.delete_stack, self.args['temp_stack'])
-        
         self.output({"image_directory": self.args['image_directory'],
                      "temp_stack": self.args['temp_stack']})
+
 
 if __name__ == "__main__":
     mod = RenderSectionAtScale(input_data=example)

--- a/rendermodules/materialize/schemas.py
+++ b/rendermodules/materialize/schemas.py
@@ -47,6 +47,7 @@ class RenderSectionAtScaleParameters(RenderParameters):
         missing=20,
         description='number of parallel threads to use')
 
+
 class RenderSectionAtScaleOutput(argschema.schemas.DefaultSchema):
     image_directory = InputDir(
         required=True,

--- a/rendermodules/utilities/pillow_utils.py
+++ b/rendermodules/utilities/pillow_utils.py
@@ -1,0 +1,3 @@
+from PIL import Image
+
+Image.MAX_IMAGE_PIXELS = None


### PR DESCRIPTION
implements consistent downsample functionality in make_montage_scapes which could enable a cleaner montage-set based processing workflow for automated processing.  In addition, this resolves #108 by adding a utilities directory with a custom `PIL.Image` class as detailed in the issue.