### PR TITLE
qc: fix slow loops, improve numpy operations, share tilespecs when po…

### DIFF
--- a/rendermodules/em_montage_qc/detect_montage_defects.py
+++ b/rendermodules/em_montage_qc/detect_montage_defects.py
@@ -6,6 +6,7 @@ import numpy as np
 import renderapi
 import time
 import requests
+from six import viewkeys
 from rendermodules.residuals import compute_residuals as cr
 from rendermodules.em_montage_qc.schemas import DetectMontageDefectsParameters, DetectMontageDefectsParametersOutput
 from ..module.render_module import RenderModule, RenderModuleException
@@ -52,27 +53,27 @@ example = {
 }
 '''
 
-def detect_seams(render, stack, match_collection, match_owner, z, residual_threshold=8, distance=60, min_cluster_size=15):
+def detect_seams(render, stack, match_collection, match_owner, z, residual_threshold=8, distance=60, min_cluster_size=15, tspecs=None):
     # seams will always be computed for montages using montage point matches
     # but the input stack can be either montage, rough, or fine
     # Compute residuals and other stats for this z
-    stats = cr.compute_residuals_within_group(render, stack, match_owner, match_collection, z)
-    
+    stats = cr.compute_residuals_within_group(render, stack, match_owner, match_collection, z, tilespecs=tspecs)
+
     # get mean positions of the point matches as numpy array
     pt_match_positions = np.concatenate(stats['pt_match_positions'].values(), 0)
     # get the tile residuals
     tile_residuals = np.concatenate(stats['tile_residuals'].values())
-    
+
     # threshold the points based on residuals
     new_pts = pt_match_positions[np.where(tile_residuals >= residual_threshold),:][0]
-    
+
     # construct a KD Tree using these points
     tree = cKDTree(new_pts)
     # construct a networkx graph
     G = nx.Graph()
     # find the pairs of points within a distance to each other
     pairs = tree.query_pairs(r=distance)
-    G.add_edges_from(list(pairs))
+    G.add_edges_from(pairs)
     # get the connected subraphs from G
     #Gc = nx.connected_component_subgraphs(G)
     Gc = nx.connected_components(G)
@@ -106,17 +107,17 @@ def detect_seams_old(render, stack, match_collection, match_owner, z, residual_t
     for p, tr in zip(pt_match_positions, tile_residuals):
         if tr >= residual_threshold:
             new_pts.append(p)
-    
+
     new_pts = np.array(new_pts)
     # construct a KD Tree using these points
     tree = KDTree(new_pts)
     # construct a networkx graph
     G = nx.Graph()
-    
+
     # iterate through each point to get its nearest neighbors within a distance
     for m, npt in enumerate(new_pts):
         idx = tree.query_ball_point(npt, r=distance)
-        
+
         # add edge to G for each neighbor
         [G.add_edge(m, id) for id in idx]
     # get the connected subraphs from G
@@ -133,23 +134,28 @@ def detect_seams_old(render, stack, match_collection, match_owner, z, residual_t
         x_pts = pts[:,0]
         y_pts = pts[:,1]
         centroids.append([np.sum(x_pts)/len(pts), np.sum(y_pts)/len(pts)])
-    
+
     return centroids
 '''
 
-def detect_disconnected_tiles(render, prestitched_stack, poststitched_stack, z):
+
+def detect_disconnected_tiles(render, prestitched_stack, poststitched_stack,
+                              z, pre_tilespecs=None, post_tilespecs=None):
     session = requests.session()
     # get the tilespecs for both prestitched_stack and poststitched_stack
-    pre_tilespecs = render.run(
-                        renderapi.tilespec.get_tile_specs_from_z,
-                        prestitched_stack,
-                        z,
-                        session=session)
-    post_tilespecs = render.run(
-                        renderapi.tilespec.get_tile_specs_from_z,
-                        poststitched_stack,
-                        z,
-                        session=session)
+
+    if pre_tilespecs is None:
+        pre_tilespecs = render.run(
+                            renderapi.tilespec.get_tile_specs_from_z,
+                            prestitched_stack,
+                            z,
+                            session=session)
+    if post_tilespecs is None:
+        post_tilespecs = render.run(
+                            renderapi.tilespec.get_tile_specs_from_z,
+                            poststitched_stack,
+                            z,
+                            session=session)
     # pre tile_ids
     pre_tileIds = []
     pre_tileIds = [ts.tileId for ts in pre_tilespecs]
@@ -159,43 +165,55 @@ def detect_disconnected_tiles(render, prestitched_stack, poststitched_stack, z):
     missing_tileIds = list(set(pre_tileIds) - set(post_tileIds))
     session.close()
     return missing_tileIds
-def detect_stitching_gaps(render, prestitched_stack, poststitched_stack, z):
+
+
+def detect_stitching_gaps(render, prestitched_stack, poststitched_stack,
+                          z, pre_tilespecs=None, tilespecs=None):
     session = requests.session()
     # setup an rtree to find overlapping tiles
     pre_ridx = rindex.Index()
     # setup a graph to store overlapping tiles
     G1 = nx.Graph()
     # get the tilespecs for both prestitched_stack and poststitched_stack
-    pre_tilespecs = render.run(
-                        renderapi.tilespec.get_tile_specs_from_z,
-                        prestitched_stack,
-                        z,
-                        session=session)
-    tilespecs = render.run(
-                        renderapi.tilespec.get_tile_specs_from_z,
-                        poststitched_stack,
-                        z,
-                        session=session)
+    if pre_tilespecs is None:
+        pre_tilespecs = render.run(
+                            renderapi.tilespec.get_tile_specs_from_z,
+                            prestitched_stack,
+                            z,
+                            session=session)
+    if tilespecs is None:
+        tilespecs = render.run(
+                            renderapi.tilespec.get_tile_specs_from_z,
+                            poststitched_stack,
+                            z,
+                            session=session)
     # insert the prestitched_tilespecs into rtree with their bounding boxes to find overlaps
-    [pre_ridx.insert(i, (ts.minX, ts.minY, ts.maxX, ts.maxY)) for i, ts in enumerate(pre_tilespecs)]
+    for i, ts in enumerate(pre_tilespecs):
+        pre_ridx.insert(i, ts.bbox)
+
     pre_tileIds = {}
     for i, ts in enumerate(pre_tilespecs):
         pre_tileIds[ts.tileId] = i
-        nodes = list(pre_ridx.intersection((ts.minX, ts.minY, ts.maxX, ts.maxY)))
+        nodes = list(pre_ridx.intersection(ts.bbox))
         nodes.remove(i)
         [G1.add_edge(i, node) for node in nodes]
-    # G1 contains the prestitched_stack tiles and the degree of each node representing
+    # G1 contains the prestitched_stack tile)s and the degree of each node representing
     # the number of tiles that overlap
     # This overlap count has to match in the poststitched_stack
     G2 = nx.Graph()
     post_ridx = rindex.Index()
-    [post_ridx.insert(pre_tileIds[ts.tileId], (ts.minX, ts.minY, ts.maxX, ts.maxY)) for ts in tilespecs if ts.tileId in pre_tileIds.keys()]
+    tileId_to_ts = {ts.tileId: ts for ts in tilespecs}
+    shared_tileIds = viewkeys(tileId_to_ts) & viewkeys(pre_tileIds)
+    [post_ridx.insert(pre_tileIds[tId], tileId_to_ts[tId].bbox) for tId in shared_tileIds]
     for ts in tilespecs:
-        if ts.tileId in pre_tileIds.keys():
+        try:
             i = pre_tileIds[ts.tileId]
-            nodes = list(post_ridx.intersection((ts.minX, ts.minY, ts.maxX, ts.maxY)))
-            nodes.remove(i)
-            [G2.add_edge(i, node) for node in nodes]
+        except KeyError:
+            continue
+        # i = pre_tileIds[ts.tileId]
+        nodes = list(post_ridx.intersection(ts.bbox))
+        nodes.remove(i)
+        [G2.add_edge(i, node) for node in nodes]
     # Now G1 and G2 have the same index for the same tileId
     # comparing the degree of each node pre and post stitching should reveal stitching gaps
     #tileIds = nx.get_node_attributes(G2, 'tileId')
@@ -206,40 +224,83 @@ def detect_stitching_gaps(render, prestitched_stack, poststitched_stack, z):
             gap_tiles.append(tileId)
     session.close()
     return gap_tiles
+
+
+def get_pre_post_tspecs(render, prestitched_stack, poststitched_stack, z):
+    session = requests.session()
+    pre_tilespecs = render.run(
+                        renderapi.tilespec.get_tile_specs_from_z,
+                        prestitched_stack,
+                        z,
+                        session=session)
+    post_tilespecs = render.run(
+                        renderapi.tilespec.get_tile_specs_from_z,
+                        poststitched_stack,
+                        z,
+                        session=session)
+    session.close()
+    return pre_tilespecs, post_tilespecs
+
+
+def run_analysis(render, prestitched_stack, poststitched_stack, match_collection,
+                 match_collection_owner, residual_threshold, neighbor_distance,
+                 min_cluster_size, z):
+    pre_tspecs, post_tspecs = get_pre_post_tspecs(
+        render, prestitched_stack, poststitched_stack, z)
+    disconnected_tiles = detect_disconnected_tiles(
+        render, prestitched_stack, poststitched_stack, z, pre_tspecs,
+        post_tspecs)
+    gap_tiles = detect_stitching_gaps(
+        render, prestitched_stack, poststitched_stack, z,
+        pre_tspecs, post_tspecs)
+    seam_centroids = detect_seams(
+        render, poststitched_stack,  match_collection, match_collection_owner,
+        z, residual_threshold=residual_threshold, distance=neighbor_distance,
+        min_cluster_size=min_cluster_size, tspecs=post_tspecs)
+
+    return disconnected_tiles, gap_tiles, seam_centroids
+
+
 def detect_stitching_mistakes(render, prestitched_stack, poststitched_stack, match_collection, match_collection_owner, residual_threshold, neighbor_distance, min_cluster_size, zvalues, pool_size=20):
-    mypartial1 = partial(detect_disconnected_tiles, 
-                         render, 
-                         prestitched_stack, 
-                         poststitched_stack)
-    mypartial2 = partial(detect_stitching_gaps, 
-                         render, 
-                         prestitched_stack, 
-                         poststitched_stack)
-    mypartial3 = partial(detect_seams, 
-                         render, 
-                         poststitched_stack, 
-                         match_collection, 
-                         match_collection_owner, 
-                         residual_threshold=residual_threshold, 
-                         distance=neighbor_distance,
-                         min_cluster_size=min_cluster_size)
-    disconnected_tiles = []
-    gap_tiles = []
-    seam_centroids = []
+    mypartial0 = partial(
+        run_analysis, render, prestitched_stack, poststitched_stack,
+        match_collection, match_collection_owner, residual_threshold,
+        neighbor_distance, min_cluster_size)
+    # mypartial1 = partial(detect_disconnected_tiles,
+    #                      render,
+    #                      prestitched_stack,
+    #                      poststitched_stack)
+    # mypartial2 = partial(detect_stitching_gaps,
+    #                      render,
+    #                      prestitched_stack,
+    #                      poststitched_stack)
+    # mypartial3 = partial(detect_seams,
+    #                      render,
+    #                      poststitched_stack,
+    #                      match_collection,
+    #                      match_collection_owner,
+    #                      residual_threshold=residual_threshold,
+    #                      distance=neighbor_distance,
+    #                      min_cluster_size=min_cluster_size)
+
     with renderapi.client.WithPool(pool_size) as pool:
-        disconnected_tiles = pool.map(mypartial1, zvalues)
-        gap_tiles = pool.map(mypartial2, zvalues)
-        seam_centroids = pool.map(mypartial3, zvalues)
+        disconnected_tiles, gap_tiles, seam_centroids = zip(*pool.map(
+            mypartial0, zvalues))
+        # disconnected_tiles = pool.map(mypartial1, zvalues)
+        # gap_tiles = pool.map(mypartial2, zvalues)
+        # seam_centroids = pool.map(mypartial3, zvalues)
     #for z in zvalues:
     #    disconnected_tiles.append(detect_disconnected_tiles(render, prestitched_stack, poststitched_stack, z))
     #    gap_tiles.append(detect_stitching_gaps(render, prestitched_stack, poststitched_stack, z))
     #    seam_centroids.append(detect_seams(render, poststitched_stack, match_collection, match_collection_owner, z, distance=80))
     return disconnected_tiles, gap_tiles, seam_centroids
+
+
 def check_status_of_stack(render, stack, zvalues):
     status = render.run(renderapi.stack.get_full_stack_metadata,
                         stack)
     new_stack = stack
-    
+
     #if (status['state'].find('LOADING') >= 0):
     if status['state'] == 'LOADING':
         # clone the stack
@@ -251,12 +312,13 @@ def check_status_of_stack(render, stack, zvalues):
                                     new_stack,
                                     zs=zvalues,
                                     render=render)
-        
+
     return status['state'], new_stack
-                                
+
+
 class DetectMontageDefectsModule(RenderModule):
     default_output_schema = DetectMontageDefectsParametersOutput
-    default_schema = DetectMontageDefectsParameters    
+    default_schema = DetectMontageDefectsParameters
     def run(self):
         zvalues1 = self.render.run(renderapi.stack.get_z_values_for_stack,
                                 self.args['poststitched_stack'])
@@ -264,13 +326,13 @@ class DetectMontageDefectsModule(RenderModule):
         zvalues = list(set(zvalues1).intersection(set(zrange)))
         if len(zvalues) == 0:
             raise RenderModuleException('No valid zvalues found in stack for given range {} - {}'.format(self.args['minZ'], self.args['maxZ']))
-            
+
         # check if pre or post stitched stack is in LOADING state.
         # if so, clone them to new stacks
         status1, new_prestitched = check_status_of_stack(self.render,
                                                 self.args['prestitched_stack'],
                                                 zvalues)
-        
+
         status2, new_poststitched = check_status_of_stack(self.render,
                                                  self.args['poststitched_stack'],
                                                  zvalues)
@@ -298,14 +360,14 @@ class DetectMontageDefectsModule(RenderModule):
         combinedz = list(set(holes + gaps + seams))
         qc_passed_sections = set(zvalues) - set(combinedz)
         centroids = [seam_centroids[i] for i in seams_indices]
-        
+
         self.args['output_html'] = self.args['out_html_dir']
         if len(combinedz) > 0:
             if self.args['plot_sections']:
                 self.args['output_html'] = plot_section_maps(self.render, new_poststitched, combinedz, out_html_dir=self.args['output_html'])
-                
+
         self.output({'output_html':self.args['output_html'],
-                     'qc_passed_sections': qc_passed_sections, 
+                     'qc_passed_sections': qc_passed_sections,
                      'hole_sections': holes,
                      'gap_sections':gaps,
                      'seam_sections':seams,
@@ -314,7 +376,7 @@ class DetectMontageDefectsModule(RenderModule):
         #if status1.find('LOADING') >= 0:
         if status1 == 'LOADING':
             self.render.run(renderapi.stack.delete_stack, new_prestitched)
-        
+
         #if status2.find('LOADING') >= 0:
         if status2 == 'LOADING':
             self.render.run(renderapi.stack.delete_stack, new_poststitched)


### PR DESCRIPTION
…ssible

Running this on a recent EM montage section takes the time to do a single section from almost exactly 1 minute to ~24 seconds by minimizing api calls and using more scalable operations inside for loops.