### PR TITLE
Tmpfile cleanup in downsample

### DIFF
--- a/integration_tests/test_rough_align.py
+++ b/integration_tests/test_rough_align.py
@@ -542,7 +542,8 @@ def test_make_montage_stack_without_downsamples(render, one_tile_montage, tmpdir
                                     render_params['project'],
                                     tagstr,
                                     params['imgformat'],
-                                    Z)
+                                    Z,
+                                    pool_size=pool_size)
 
 
 

--- a/rendermodules/materialize/render_downsample_sections.py
+++ b/rendermodules/materialize/render_downsample_sections.py
@@ -59,8 +59,6 @@ def create_tilespecs_without_mipmaps(render, montage_stack, level, z):
     for t in ts:
         t.ip.mipMapLevels = [mmL for mmL in t.ip.mipMapLevels
                              if mmL.level == level]
-    # tempjson = renderapi.utils.renderdump_temp(ts, indent=4)
-    # return tempjson
     return ts
 
 
@@ -99,13 +97,6 @@ class RenderSectionAtScale(RenderModule):
             render.run(renderapi.stack.set_stack_state,
                        temp_no_mipmap_stack, state='LOADING')
 
-            # import json files into temp_no_mipmap_stack
-            # this also sets the stack's state to COMPLETE
-            # render.run(renderapi.client.import_jsonfiles_parallel,
-            #            temp_no_mipmap_stack,
-            #            jsonfiles,
-            #            poolsize=pool_size,
-            #            close_stack=True)
             render.run(renderapi.client.import_tilespecs_parallel,
                        temp_no_mipmap_stack,
                        all_tilespecs,


### PR DESCRIPTION
Workflow has been failing on render downsample because of a temp file "leak" when the node had a broken scratch directory.  It's better for rendermodules to pick up after itself than depend on external tools.