### PR TITLE
Poolfix downsample

### DIFF
--- a/integration_tests/test_rough_align.py
+++ b/integration_tests/test_rough_align.py
@@ -542,7 +542,8 @@ def test_make_montage_stack_without_downsamples(render, one_tile_montage, tmpdir
                                     render_params['project'],
                                     tagstr,
                                     params['imgformat'],
-                                    Z)
+                                    Z,
+                                    pool_size=pool_size)
 
 
 

--- a/integration_tests/test_rough_align.py
+++ b/integration_tests/test_rough_align.py
@@ -7,6 +7,8 @@ import json
 import glob
 import copy
 import marshmallow as mm
+import urllib
+import urlparse
 from test_data import (ROUGH_MONTAGE_TILESPECS_JSON,
                        ROUGH_MONTAGE_TRANSFORM_JSON,
                        ROUGH_POINT_MATCH_COLLECTION,
@@ -504,8 +506,7 @@ def test_render_downsample_with_mipmaps(render, one_tile_montage, tmpdir_factory
         assert(1021 not in zvalues)
 
 
-
-def test_make_montage_stack_without_downsamples(render, one_tile_montage, tmpdir_factory):
+def make_montage_stack_without_downsamples(render, one_tile_montage, tmpdir_factory):
     # testing for make montage scape stack without having downsamples generated
     tmp_dir = str(tmpdir_factory.mktemp('downsample'))
     output_stack = '{}_Downsample'.format(one_tile_montage)
@@ -544,6 +545,38 @@ def test_make_montage_stack_without_downsamples(render, one_tile_montage, tmpdir
                                     params['imgformat'],
                                     Z,
                                     pool_size=pool_size)
+
+
+def test_make_montage_stack_module_without_downsamples(
+        render, one_tile_montage, tmpdir_factory):
+    # testing for make montage scape stack without having downsamples generated
+    tmp_dir = str(tmpdir_factory.mktemp('downsample'))
+    output_stack = '{}_Downsample'.format(one_tile_montage)
+    params = {
+        "render": render_params,
+        "montage_stack": one_tile_montage,
+        "output_stack": output_stack,
+        "image_directory": tmp_dir,
+        "imgformat": "png",
+        "scale": 0.1,
+        "zstart": 1020,
+        "zend": 1020
+    }
+
+    outjson = 'test_montage_scape_output.json'
+    mod = MakeMontageScapeSectionStack(
+        input_data=params, args=['--output_json', outjson])
+    mod.run()
+
+    tspecs = render.run(
+        renderapi.tilespec.get_tile_specs_from_stack, output_stack)
+
+    tsfn = urllib.unquote(urlparse.urlparse(
+        tspecs[0].ip.get(0)['imageUrl']).path)
+    assert os.path.isfile(tsfn)
+    assert os.path.basename(tsfn) == '1020.0.png'
+
+
 
 
 

--- a/rendermodules/dataimport/make_montage_scapes_stack.py
+++ b/rendermodules/dataimport/make_montage_scapes_stack.py
@@ -242,7 +242,8 @@ class MakeMontageScapeSectionStack(StackOutputModule):
             level=self.args['level'],
             pool_size=1,
             doFilter=self.args['doFilter'],
-            fillWithNoise=self.args['fillWithNoise'])
+            fillWithNoise=self.args['fillWithNoise'],
+            do_mp=False)
 
         with renderapi.client.WithPool(
                 self.args['pool_size_materialize']) as pool:

--- a/rendermodules/materialize/render_downsample_sections.py
+++ b/rendermodules/materialize/render_downsample_sections.py
@@ -59,8 +59,6 @@ def create_tilespecs_without_mipmaps(render, montage_stack, level, z):
     for t in ts:
         t.ip.mipMapLevels = [mmL for mmL in t.ip.mipMapLevels
                              if mmL.level == level]
-    # tempjson = renderapi.utils.renderdump_temp(ts, indent=4)
-    # return tempjson
     return ts
 
 
@@ -99,13 +97,6 @@ class RenderSectionAtScale(RenderModule):
             render.run(renderapi.stack.set_stack_state,
                        temp_no_mipmap_stack, state='LOADING')
 
-            # import json files into temp_no_mipmap_stack
-            # this also sets the stack's state to COMPLETE
-            # render.run(renderapi.client.import_jsonfiles_parallel,
-            #            temp_no_mipmap_stack,
-            #            jsonfiles,
-            #            poolsize=pool_size,
-            #            close_stack=True)
             render.run(renderapi.client.import_tilespecs_parallel,
                        temp_no_mipmap_stack,
                        all_tilespecs,


### PR DESCRIPTION
This PR includes changes from #124.

Nested multiprocessing pools introduced a bug in #109.  Current behavior will raise an `AssertionError: daemonic processes are not allowed to have children` on calling any of the processing pools in render downsample from the multiprocessing pool over the input zs to this module.  Since those cases should be mutually exclusive it seems like we can just serialize the inner operations (and their pool size is set to 1 by default).

I modified the tests to catch this failure and show that using a `ThreadPool`-based `WithPool` interface will solve this issue.  We could potentially have a serial `map` function on a dummy `WithPool` as well, but I have not written/tested one.
