### PR TITLE
render_downsample: decrease chance of collisions for tempstack

### DIFF
--- a/rendermodules/materialize/render_downsample_sections.py
+++ b/rendermodules/materialize/render_downsample_sections.py
@@ -96,8 +96,9 @@ class RenderSectionAtScale(RenderModule):
         if stack_has_mipmaps:
             print("stack has mipmaps")
             # clone the input stack to a temporary one with level 1 mipmap alone
-            temp_no_mipmap_stack = "{}_no_mml_t{}".format(
-                input_stack, time.strftime("%m%d%y_%H%M%S"))
+            temp_no_mipmap_stack = "{}_no_mml_zs{}_ze{}_t{}".format(
+                input_stack, min(zvalues), max(zvalues),
+                time.strftime("%m%d%y_%H%M%S"))
 
             mypartial = partial(create_tilespecs_without_mipmaps,
                                 render, input_stack, level)


### PR DESCRIPTION
I have a suspicion that the stacks used for making downsamples are colliding when run in a largely-parallel environment.  Adding some z values to the stacks to make them more unique.