### PR TITLE
Mipmaptypefix

### DIFF
--- a/integration_tests/test_dataimport.py
+++ b/integration_tests/test_dataimport.py
@@ -49,12 +49,14 @@ def test_generate_EM_metadata(render):
     renderapi.stack.delete_stack(ex['stack'], render=render)
     assert len(expected_tileIds.symmetric_difference(delivered_tileIds)) == 0
 
-def validate_mipmap_generated(in_ts,out_ts,levels,imgformat='tif'):
+
+def validate_mipmap_generated(in_ts, out_ts, levels, imgformat='tif',
+                              targetmode='L', **kwargs):
     # make sure that the corresponding tiles' l0s match
     inpath = generate_mipmaps.get_filepath_from_tilespec(in_ts)
     outpath = generate_mipmaps.get_filepath_from_tilespec(out_ts)
 
-    assert inpath==outpath
+    assert inpath == outpath
 
     # make sure all levels have been assigned
     assert list(sorted(out_ts.ip.levels)) == list(map(str, range(levels + 1)))
@@ -67,10 +69,11 @@ def validate_mipmap_generated(in_ts,out_ts,levels,imgformat='tif'):
 
     for lvl, mmL in iteritems(out_ts.ip):
         fn = urllib.parse.unquote(urllib.parse.urlparse(mmL.imageUrl).path)
-        ext=os.path.splitext(fn)[1]
+        ext = os.path.splitext(fn)[1]
         if (lvl != "0"):
             assert ext[1:] == imgformat
         with Image.open(fn) as im:
+            assert im.mode == targetmode
             w, h = im.size
         assert w == expected_width // (2 ** int(lvl))
         assert h == expected_height // (2 ** int(lvl))
@@ -126,7 +129,8 @@ def apply_generated_mipmaps(r, output_stack, generate_params,z=None):
         assert not (viewkeys(in_tileIdtotspecs) ^ viewkeys(out_tileIdtotspecs))
         for tId, out_ts in iteritems(out_tileIdtotspecs):
             in_ts = in_tileIdtotspecs[tId]
-            validate_mipmap_generated(in_ts,out_ts,ex['levels'])
+            validate_mipmap_generated(
+                in_ts, out_ts, ex['levels'], targetmode='L')
             # make sure reference transforms are intact
             assert isinstance(in_ts.tforms[0],
                               renderapi.transform.ReferenceTransform)

--- a/integration_tests/test_dataimport.py
+++ b/integration_tests/test_dataimport.py
@@ -51,7 +51,7 @@ def test_generate_EM_metadata(render):
 
 
 def validate_mipmap_generated(in_ts, out_ts, levels, imgformat='tif',
-                              targetmode='L', **kwargs):
+                              targetmode=None, **kwargs):
     # make sure that the corresponding tiles' l0s match
     inpath = generate_mipmaps.get_filepath_from_tilespec(in_ts)
     outpath = generate_mipmaps.get_filepath_from_tilespec(out_ts)
@@ -66,6 +66,10 @@ def validate_mipmap_generated(in_ts, out_ts, levels, imgformat='tif',
     assert in_ts.height == out_ts.height
     expected_width = out_ts.width
     expected_height = out_ts.height
+
+    if targetmode is None:
+        with Image.open(inpath) as im:
+            targetmode = im.mode
 
     for lvl, mmL in iteritems(out_ts.ip):
         fn = urllib.parse.unquote(urllib.parse.urlparse(mmL.imageUrl).path)
@@ -130,7 +134,7 @@ def apply_generated_mipmaps(r, output_stack, generate_params,z=None):
         for tId, out_ts in iteritems(out_tileIdtotspecs):
             in_ts = in_tileIdtotspecs[tId]
             validate_mipmap_generated(
-                in_ts, out_ts, ex['levels'], targetmode='L')
+                in_ts, out_ts, ex['levels'])
             # make sure reference transforms are intact
             assert isinstance(in_ts.tforms[0],
                               renderapi.transform.ReferenceTransform)

--- a/rendermodules/dataimport/create_mipmaps.py
+++ b/rendermodules/dataimport/create_mipmaps.py
@@ -58,10 +58,12 @@ def mipmap_block_reduce(im, levels_file_map, block_func="mean",
             "invalid block_reduce function {}".format(e))
 
     tempimg = numpy.array(im)
+    target_dtype = tempimg.dtype
     lastlevel = 0
     for level, outpath in levels_file_map.items():
         for i in xrange(lastlevel, level):
-            tempimg = block_reduce(tempimg, (2, 2), func=reduce_func)
+            tempimg = block_reduce(tempimg, (2, 2), func=reduce_func).astype(
+                target_dtype)
 
         # is it okay to do non-progressive downsampling (below)?
         # tempimg = block_reduce(


### PR DESCRIPTION
block_reduce was previously not preserving the numpy array type and writing mipmaps in float mode 'F' rather than uint8 'L'.  I think Render is naive in interpreting this and did not notice, but this is a high-priority fix.