### PR TITLE
rough_align: include lower level mipmaps in downsample tempstack

### DIFF
--- a/integration_tests/test_rough_align.py
+++ b/integration_tests/test_rough_align.py
@@ -457,7 +457,14 @@ def test_render_downsample_with_mipmaps(render, one_tile_montage, tmpdir_factory
     ex3 = dict(ex2, **{'minZ': 1 , 'maxZ': 2})
 
     #stack_has_mipmaps = check_stack_for_mipmaps(render, ex['input_stack'], [1020])
-    tempjson = create_tilespecs_without_mipmaps(render, ex['input_stack'], 0, 1020)
+    # tempjson = create_tilespecs_without_mipmaps(render, ex['input_stack'], 0, 1020)
+
+    # generate tilespecs used for rendering stack input
+    maxlvl = 1
+    tspecs = create_tilespecs_without_mipmaps(render, ex['input_stack'], maxlvl, 1020)
+    ts_levels = {int(i) for l in (ts.ip.levels for ts in tspecs) for i in l}
+    # levels > maxlevel should not be included if
+    assert not ts_levels.difference(set(range(maxlvl + 1)))
 
     mod = RenderSectionAtScale(input_data=ex, args=[])
     mod.run()

--- a/rendermodules/materialize/render_downsample_sections.py
+++ b/rendermodules/materialize/render_downsample_sections.py
@@ -56,9 +56,12 @@ def check_stack_for_mipmaps(render, input_stack, zvalues):
 
 
 def create_tilespecs_without_mipmaps(render, montage_stack, level, z):
+    """return tilespecs missing mipmaplevels above the specified level"""
     ts = render.run(renderapi.tilespec.get_tile_specs_from_z, montage_stack, z)
     for t in ts:
-        t.ip = renderapi.tilespec.ImagePyramid({level: t.ip[level]})
+        t.ip = renderapi.tilespec.ImagePyramid({
+            lvl: mipmap for lvl, mipmap in t.ip.items()
+            if int(lvl) <= int(level)})
     return ts
 
 


### PR DESCRIPTION
Some extremely distorted tiles have been causing issues in materializing downsampled montages.  These cases are looking for level 0 mipmaps and failing with an error like:
```
java.lang.IllegalArgumentException: The highest resolution mipmap for file:/allen/programs/celltypes/production/wijem/workflow_data/production/mipmap/em_montage_17797_1R_z130208_2018_06_18_18_15_56_00_00/1/allen/programs/celltypes/production/wijem/incoming_data/17797_1R_Tape151_TEMCA2_04_000208_0/20180618111803520_17797_1R_Tape151_TEMCA2_04_000208_0_45_3.tif.tif is level 1 but a level 0 mipmap is needed.  Upscaling is not currently supported.
```

This PR modifies downsample generation to keep all tilespecs below the target level, allowing level 0s to be used when necessary.