### PR TITLE
remap_zs: adding separate module to remap z values

### DIFF
--- a/integration_tests/test_consolidate.py
+++ b/integration_tests/test_consolidate.py
@@ -10,7 +10,7 @@ import renderapi
 from test_data import render_params, cons_ex_tilespec_json, cons_ex_transform_json
 from rendermodules.module.render_module import RenderModuleException
 from rendermodules.stack.consolidate_transforms import ConsolidateTransforms, process_z, consolidate_transforms
-from rendermodules.stack import redirect_mipmaps
+from rendermodules.stack import redirect_mipmaps, remap_zs
 
 EPSILON = .001
 render_params['project'] = "consolidate_test"
@@ -137,3 +137,46 @@ def test_redirect_mipMapLevels(render, test_stack, tmpdir):
         ts.ip[0].imageUrl).path)).startswith(
             os.path.abspath(str(tmpdir)))
                 for ts in modified_tspecs])
+
+
+@pytest.mark.parametrize("remap_sectionId", [True, False])
+def test_remap_zs(render, test_stack, remap_sectionId):
+    output_stack = "remap_zs_test"
+    out_fn = "remapzsout.json"
+    zValues = renderapi.stack.get_z_values_for_stack(test_stack, render=render)
+    new_zValues = [z + 25 for z in zValues]
+    input_d = dict(remap_zs.example_input, **{
+        "input_stack": test_stack,
+        "output_stack": output_stack,
+        "zValues": zValues,
+        "new_zValues": new_zValues,
+        "remap_sectionId": remap_sectionId,
+        "render": render.DEFAULT_KWARGS
+    })
+
+    in_tspecs = renderapi.tilespec.get_tile_specs_from_stack(
+        test_stack, render=render)
+    mod = remap_zs.RemapZsModule(
+        input_data=input_d, args=['--output_json', out_fn])
+    mod.run()
+
+    out_tspecs = renderapi.tilespec.get_tile_specs_from_stack(
+        output_stack, render=render)
+
+    assert new_zValues == renderapi.stack.get_z_values_for_stack(
+        output_stack, render=render)
+
+    # tileIds should be preserved
+    assert not ({ts.tileId for ts in in_tspecs} ^
+                {ts.tileId for ts in out_tspecs})
+
+    if remap_sectionId:
+        # should be symmetric difference
+        assert ({ts.layout.sectionId for ts in in_tspecs} ^
+                {ts.layout.sectionId for ts in out_tspecs})
+
+        assert ({ts.layout.sectionId for ts in out_tspecs} ==
+                {mod.sectionId_from_z(ts.z) for ts in out_tspecs})
+    else:
+        assert ({ts.layout.sectionId for ts in in_tspecs} ==
+                {ts.layout.sectionId for ts in out_tspecs})

--- a/rendermodules/stack/remap_zs.py
+++ b/rendermodules/stack/remap_zs.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+import renderapi
+
+from rendermodules.module.render_module import (StackTransitionModule,
+                                                RenderModuleException)
+from rendermodules.stack.schemas import RemapZsParameters, RemapZsOutput
+
+
+example_input = {
+    "input_stack": "TEST_IMPORT_FROMMD",
+    "output_stack": "TEST_remzs",
+    "pool_size": 10,
+    "render": {
+        "host": "em-131fs",
+        "port": 8080,
+        "owner": "russelt",
+        "project": "RENDERAPI_TEST",
+        "client_scripts": "/allen/aibs/pipeline/image_processing/volume_assembly/render-jars/production/scripts/"
+    },
+    "close_stack": False,
+    "overwrite_zlayer": True,
+    "zValues": [0],
+    "new_zValues": [10000],
+
+}
+
+
+class RemapZsModule(StackTransitionModule):
+    default_schema = RemapZsParameters
+    default_output_schema = RemapZsOutput
+
+    @staticmethod
+    def sectionId_from_z(z):
+        return "{}.0".format(int(float(z)))
+
+    def run(self):
+        if len(self.zValues) != len(self.args['new_zValues']):
+            raise RenderModuleException(
+                "zValues with length {} cannot be mapped to "
+                "zValues with length {}".format(
+                    len(self.zValues), len(self.args['new_zValues'])))
+        for z, newz in zip(self.zValues, self.args['new_zValues']):
+            resolvedtiles = renderapi.resolvedtiles.get_resolved_tiles_from_z(
+                self.input_stack, z, render=self.render)
+            for ts in resolvedtiles.tilespecs:
+                ts.z = newz
+                if self.args.get('remap_sectionId'):
+                    ts.layout.sectionId = self.sectionId_from_z(newz)
+            self.output_tilespecs_to_stack(
+                resolvedtiles.tilespecs,
+                sharedTransforms=resolvedtiles.transforms,
+                zValues=[z])
+        self.output({
+            "zValues": self.zValues,
+            "output_stack": self.output_stack
+        })
+
+
+if __name__ == "__main__":
+    mod = RemapZsModule(input_data=example_input)
+    mod.run()

--- a/rendermodules/stack/schemas.py
+++ b/rendermodules/stack/schemas.py
@@ -49,3 +49,13 @@ class RedirectMipMapsParameters(StackTransitionParameters):
 class RedirectMipMapsOutput(DefaultSchema):
     zValues = List(Int, required=True)
     output_stack = Str(required=True)
+
+
+class RemapZsParameters(StackTransitionParameters):
+    remap_sectionId = Boolean(required=False)
+    new_zValues = List(Int, required=True)
+
+
+class RemapZsOutput(DefaultSchema):
+    zValues = List(Int, required=True)
+    output_stack = Str(required=True)


### PR DESCRIPTION
adding module to map z values to new z values, optionally mapping sectionIds as well. Can be used in workflow to build chunk stacks and use offset z indices in a non-aggregated stack as output for generate downsamples.