### PR TITLE
Filter list options

### DIFF
--- a/integration_tests/test_rough_align.py
+++ b/integration_tests/test_rough_align.py
@@ -466,7 +466,7 @@ def test_apply_rough_alignment_transform(render, montage_stack, test_do_rough_al
             ts.tforms[0], renderapi.transform.ReferenceTransform)
                     for ts in out_resolvedtiles.tilespecs])
 
-    
+
 
 # additional tests for code coverage
 def test_render_downsample_with_mipmaps(render, one_tile_montage, tmpdir_factory, test_do_rough_alignment, montage_stack):
@@ -768,3 +768,34 @@ def test_solver_default_options(render, montage_scape_stack, rough_point_match_c
 
     with pytest.raises(mm.ValidationError):
         mod.run()
+
+
+def test_filterNameList_warning_makemontagescapes(tmpdir):
+    warn_input = {
+        "render": render_params,
+        "montage_stack": "montage_stack",
+        "output_stack": "output_stack",
+        "image_directory": str(tmpdir),
+        "imgformat": "png",
+        "set_new_z": False,
+        "new_z_start": 0,
+        "scale": 0.1,
+        "zstart": 1020,
+        "zend": 1022,
+        "filterListName": "notafilter"}
+    with pytest.warns(UserWarning):
+        mod = MakeMontageScapeSectionStack(input_data=warn_input, args=[])
+
+
+def test_filterNameList_warning_rendersection(tmpdir):
+    warn_input = {
+        "render": render_params,
+        "input_stack": "one_tile_montage",
+        "image_directory": str(tmpdir),
+        "imgformat": "png",
+        "scale": 0.1,
+        "minZ": -1,
+        "maxZ": -1,
+        "filterListName": "notafilter"}
+    with pytest.warns(UserWarning):
+        mod = RenderSectionAtScale(input_data=warn_input, args=[])

--- a/rendermodules/dataimport/schemas.py
+++ b/rendermodules/dataimport/schemas.py
@@ -1,3 +1,4 @@
+import warnings
 import marshmallow as mm
 from argschema.fields import InputDir, InputFile, Str, Int, Boolean, Float
 from ..module.schemas import (StackTransitionParameters, InputStackParameters,
@@ -145,7 +146,8 @@ class MakeMontageScapeSectionStackParameters(OutputStackParameters):
         "Java heap size in GB for materialization"))
     pool_size_materialize = Int(required=False, default=1, description=(
         "number of processes to generate missing downsamples"))
-
+    filterListName = Str(required=False, description=(
+        "Apply specified filter list to all renderings"))
 
     @post_load
     def validate_data(self, data):
@@ -153,6 +155,11 @@ class MakeMontageScapeSectionStackParameters(OutputStackParameters):
             raise ValidationError('new Z start cannot be less than zero')
         elif not data['set_new_z']:
             data['new_z_start'] = min(data['zValues'])
+        # FIXME will be able to remove with render-python tweak
+        if data.get('filterListName') is not None:
+            warnings.warn(
+                "filterListName not implemented -- will use default behavior",
+                UserWarning)
 
 
 class MakeMontageScapeSectionStackOutput(DefaultSchema):

--- a/rendermodules/materialize/materialize_sections.py
+++ b/rendermodules/materialize/materialize_sections.py
@@ -44,7 +44,8 @@ class MaterializeSectionsModule(SparkModule):
             fmt=None, maxOverviewWidthAndHeight=None,
             skipInterpolation=None, binaryMask=None, label=None,
             createIGrid=None, forceGeneration=None, renderGroup=None,
-            numberOfRenderGroups=None, cleanUpPriorRun=None, explainPlan=None,
+            numberOfRenderGroups=None, cleanUpPriorRun=None,
+            filterListName=None, explainPlan=None,
             maxImageCacheGb=None, zValues=None, **kwargs):
         get_cmd_opt = cls.get_cmd_opt
         get_flag_cmd = cls.get_flag_cmd
@@ -66,6 +67,7 @@ class MaterializeSectionsModule(SparkModule):
             get_flag_cmd(forceGeneration, '--forceGeneration') +
             get_cmd_opt(renderGroup, '--renderGroup') +
             get_cmd_opt(numberOfRenderGroups, '--numberOfRenderGroups') +
+            get_cmd_opt(filterListName, '--filterListName') +
             get_flag_cmd(cleanUpPriorRun, '--cleanUpPriorRun') +
             get_flag_cmd(explainPlan, '--explainPlan') +
             get_cmd_opt(maxImageCacheGb, '--maxImageCacheGb') +

--- a/rendermodules/materialize/render_downsample_sections.py
+++ b/rendermodules/materialize/render_downsample_sections.py
@@ -86,7 +86,8 @@ class RenderSectionAtScale(RenderModule):
     def downsample_specific_mipmapLevel(
             cls, zvalues, input_stack=None, level=1, pool_size=1,
             image_directory=None, scale=None, imgformat=None, doFilter=None,
-            fillWithNoise=None, render=None, do_mp=True, **kwargs):
+            fillWithNoise=None, filterListName=None,
+            render=None, do_mp=True, **kwargs):
         # temporary hack for nested pooling woes
         poolclass = (renderapi.client.WithPool if do_mp else WithThreadPool)
 
@@ -132,7 +133,8 @@ class RenderSectionAtScale(RenderModule):
                    scale=scale,
                    format=imgformat,
                    doFilter=doFilter,
-                   fillWithNoise=fillWithNoise)
+                   fillWithNoise=fillWithNoise,
+                   filterListName=filterListName)
 
         if stack_has_mipmaps:
             # delete the temp stack

--- a/rendermodules/materialize/schemas.py
+++ b/rendermodules/materialize/schemas.py
@@ -1,9 +1,11 @@
+import warnings
 import argschema
 from rendermodules.module.schemas import (
     RenderParameters, SparkParameters, MaterializedBoxParameters,
     ZRangeParameters, RenderParametersRenderWebServiceParameters)
 from argschema.fields import (Str, OutputDir, Int, Boolean, Float,
                               List, InputDir)
+from marshmallow import post_load
 
 
 class RenderSectionAtScaleParameters(RenderParameters):
@@ -41,11 +43,21 @@ class RenderSectionAtScaleParameters(RenderParameters):
         default=-1,
         missing=-1,
         description='max Z to create the downsample section from')
+    filterListName = Str(required=False, description=(
+        "Apply specified filter list to all renderings"))
     pool_size = Int(
         required=False,
         default=20,
         missing=20,
         description='number of parallel threads to use')
+
+    @post_load
+    def validate_data(self, data):
+        # FIXME will be able to remove with render-python tweak
+        if data.get('filterListName') is not None:
+            warnings.warn(
+                "filterListName not implemented -- will use default behavior",
+                UserWarning)
 
 
 class RenderSectionAtScaleOutput(argschema.schemas.DefaultSchema):

--- a/rendermodules/module/schemas/renderclient_schemas.py
+++ b/rendermodules/module/schemas/renderclient_schemas.py
@@ -126,6 +126,8 @@ class FeatureRenderParameters(argschema.schemas.DefaultSchema):
     fillWithNoise = Boolean(required=False, description=(
         "Fill each canvas image with noise prior to rendering. "
         "True if excluded or None"))
+    renderFilterListName = Str(required=False, description=(
+        "Apply specified filter list to all renderings"))
 
 
 class FeatureStorageParameters(argschema.schemas.DefaultSchema):

--- a/rendermodules/module/schemas/renderclient_schemas.py
+++ b/rendermodules/module/schemas/renderclient_schemas.py
@@ -41,6 +41,8 @@ class MaterializedBoxParameters(argschema.schemas.DefaultSchema):
     numberOfRenderGroups = Int(required=False, description=(
         "used in conjunction with renderGroup, total number of groups "
         "being used"))
+    filterListName = Str(required=False, description=(
+        "Apply specified filter list to all renderings"))
 
 
 class ZRangeParameters(argschema.schemas.DefaultSchema):

--- a/rendermodules/pointmatch/generate_point_matches_spark.py
+++ b/rendermodules/pointmatch/generate_point_matches_spark.py
@@ -93,7 +93,9 @@ class PointMatchClientModuleSpark(SparkModule):
                             renderWithFilter=None, renderWithoutMask=None,
                             renderFullScaleWidth=None,
                             renderFullScaleHeight=None, fillWithNoise=None,
-                            rootFeatureDirectory=None,requireStoredFeatures=None,
+                            rootFeatureDirectory=None,
+                            renderFilterListName=None,
+                            requireStoredFeatures=None,
                             **kwargs):
         get_cmd_opt = cls.get_cmd_opt
         cmd = (
@@ -121,9 +123,10 @@ class PointMatchClientModuleSpark(SparkModule):
             get_cmd_opt(renderWithoutMask, '--renderWithoutMask') +
             get_cmd_opt(renderFullScaleWidth, '--renderFullScaleWidth') +
             get_cmd_opt(renderFullScaleHeight, '--renderFullScaleHeight') +
-            get_cmd_opt(fillWithNoise, '--fillWithNoise')+
-            get_cmd_opt(rootFeatureDirectory,'--rootFeatureDirectory')+
-            cls.get_flag_cmd(requireStoredFeatures,'--requireStoredFeatures'))
+            get_cmd_opt(fillWithNoise, '--fillWithNoise') +
+            get_cmd_opt(renderFilterListName, '--renderFilterListName') +
+            get_cmd_opt(rootFeatureDirectory, '--rootFeatureDirectory') +
+            cls.get_flag_cmd(requireStoredFeatures, '--requireStoredFeatures'))
         return cmd
 
     @classmethod


### PR DESCRIPTION
This PR enables input arguments for custom filter lists in the materialization and pointmatching modules.

Anything that calls a render-python client also includes a warning as renderapi does not have this option implemented currently.  Once that is resolved we can take those warnings and the associated tests out.