### PR TITLE
removing mipmap urls from downsample stack

### DIFF
--- a/rendermodules/dataimport/make_montage_scapes_stack.py
+++ b/rendermodules/dataimport/make_montage_scapes_stack.py
@@ -124,6 +124,7 @@ def create_montage_scape_tile_specs(render, input_stack, image_directory,
         t.width, t.height = im.size
     t.ip[0] = renderapi.image_pyramid.MipMap(
         imageUrl=pathlib.Path(filename).as_uri())
+    [t.ip.pop(k) for k in list(t.ip.keys()) if k != '0']
     t.minIntensity = 0
     t.maxIntensity = 255
     t.z = newz

--- a/rendermodules/rough_align/schemas.py
+++ b/rendermodules/rough_align/schemas.py
@@ -53,6 +53,7 @@ class ApplyRoughAlignmentTransformParameters(RenderParameters):
         metadata={'description':'scale of montage scapes'})
     apply_scale = mm.fields.Boolean(
         required=False,
+        default=False,
         missing=False,
         metadata={'description':'do you want to apply scale'})
     pool_size = mm.fields.Int(


### PR DESCRIPTION
1. removing mipmap urls from the downsample stack
2. adding a default value to "apply_scale" parameter in apply_rough_alignment_to_montages schema