### PR TITLE
running docker as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 FROM fcollman/render-python-client:master
 MAINTAINER Forrest Collman (forrest.collman@gmail.com)
 
-WORKDIR /shared/render-modules
-COPY . /shared/render-modules
+RUN groupadd -g 999 appuser && \
+    useradd -r -u 999 -g appuser appuser
+USER appuser
+
+WORKDIR ~/shared/render-modules
+COPY . ~/shared/render-modules
 RUN apt-get update && apt-get install -y libxcomposite-dev gcc && rm -rf /var/lib/apt/lists/*
 SHELL ["/bin/bash", "-c"]
 RUN conda create -n render-modules --clone root && source activate render-modules && conda install -y -c conda-forge rtree 
@@ -12,4 +16,4 @@ RUN source activate render-modules &&\
  pip uninstall -y opencv-python opencv-contrib-python &&\
  pip install -r requirements.txt &&\
  python setup.py install
-ENTRYPOINT ["/bin/bash","/shared/render-modules/entrypoint.sh"]
+ENTRYPOINT ["/bin/bash","~/shared/render-modules/entrypoint.sh"]


### PR DESCRIPTION
running docker as root gave access to all directories, while, some real-life failure modes occur with read-only directories, making it difficult to cover those cases in tests.