### PR TITLE
changing URL generation in create_mipmaps

### DIFF
--- a/rendermodules/dataimport/create_mipmaps.py
+++ b/rendermodules/dataimport/create_mipmaps.py
@@ -137,9 +137,10 @@ def create_mipmaps(inputImage, outputDirectory='.', method="block_reduce",
         im = im.convert('I')
         im = im.point(table, 'L')
 
+    imgbasename, ext = os.path.splitext(os.path.basename(inputImage))
     levels_file_map = {int(level): os.path.join(
         outputDirectory, str(level), '{basename}.{fmt}'.format(
-            basename=inputImage.lstrip(os.sep), fmt=outputformat))
+            basename=imgbasename, fmt=outputformat))
                        for level in mipmaplevels}
 
     try:


### PR DESCRIPTION
this seems weird to me, so I changed it.
here's an example of what it was doing, see for example imageUrl in mipmap level 1:
http://em-131db:8080/render-ws/v1/owner/TEM/project/17797_1R/stack/em_2d_montage_solved_py_zs140101_ze140101_t070618_103424/z/140101/resolvedTiles

```
import os

def before(mipmaplevels, outputDirectory, inputImage, outputformat):
    levels_file_map = {int(level): os.path.join(
        outputDirectory, str(level), '{basename}.{fmt}'.format(
            basename=inputImage.lstrip(os.sep), fmt=outputformat))
                       for level in mipmaplevels}
    for l in levels_file_map:
        print(levels_file_map[l])

def after(mipmaplevels, outputDirectory, inputImage, outputformat):
    imgbasename, ext = os.path.splitext(os.path.basename(inputImage))
    levels_file_map = {int(level): os.path.join(    
        outputDirectory, str(level), '{basename}.{fmt}'.format(
            basename=imgbasename, fmt=outputformat))
                       for level in mipmaplevels}
    for l in levels_file_map:
        print(levels_file_map[l])
```
```
In [40]: before([0,1,2,3], '/some/output/path', '/some/input/image.png', 'png')
/some/output/path/0/some/input/image.png.png
/some/output/path/1/some/input/image.png.png
/some/output/path/2/some/input/image.png.png
/some/output/path/3/some/input/image.png.png

In [41]: after([0,1,2,3], '/some/output/path', '/some/input/image.png', 'png')
/some/output/path/0/image.png
/some/output/path/1/image.png
/some/output/path/2/image.png
/some/output/path/3/image.png
```
