### PR TITLE
version opencv-python-contrib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ networkx
 bokeh
 EMaligner>=0.2.0
 matplotlib
-opencv-contrib-python
+opencv-contrib-python<3.4.3.0
 jinja2
 six
 scikit-image


### PR DESCRIPTION
3.4.3 does not default to installing non-free SIFT implementation