### PR TITLE
Meshlc py tps and affine

### DIFF
--- a/rendermodules/mesh_lens_correction/MeshAndSolveTransform.py
+++ b/rendermodules/mesh_lens_correction/MeshAndSolveTransform.py
@@ -484,11 +484,13 @@ def create_transforms(ntiles, solution, get_common=True):
         for r in rtransforms:
             transforms.append(renderapi.transform.AffineModel())
             transforms[-1].M = r.M.dot(np.linalg.inv(common))
+        ctform = renderapi.transform.AffineModel()
+        ctform.M = common
     else:
-        common = None
+        ctform = None
         transforms = rtransforms
 
-    return common, transforms
+    return ctform, transforms
 
 
 class MeshAndSolveTransform(ArgSchemaParser):

--- a/rendermodules/mesh_lens_correction/MeshAndSolveTransform.py
+++ b/rendermodules/mesh_lens_correction/MeshAndSolveTransform.py
@@ -483,7 +483,7 @@ def create_transforms(ntiles, solution, get_common=True):
         common = np.array([t.M for t in rtransforms]).mean(0)
         for r in rtransforms:
             transforms.append(renderapi.transform.AffineModel())
-            transforms[-1].M = rtransforms.M.dot(np.linalg.inv(common))
+            transforms[-1].M = r.M.dot(np.linalg.inv(common))
     else:
         common = None
         transforms = rtransforms

--- a/rendermodules/mesh_lens_correction/MeshAndSolveTransform.py
+++ b/rendermodules/mesh_lens_correction/MeshAndSolveTransform.py
@@ -480,7 +480,10 @@ def create_transforms(ntiles, solution, get_common=True):
 
     if get_common:
         transforms = []
+        # average without translations
         common = np.array([t.M for t in rtransforms]).mean(0)
+        common[0, 2] = 0.0
+        common[1, 2] = 0.0
         for r in rtransforms:
             transforms.append(renderapi.transform.AffineModel())
             transforms[-1].M = r.M.dot(np.linalg.inv(common))


### PR DESCRIPTION
this PR has 2 components:
1) replaces java client ThinPlateSplineClient call with new render-python renderapi.transform.ThinPlateSplineTransform.estimate() call.
2) in MeshAndSolveTransform, a common affine is collected from the solve results and included in the resulting transform. This will allow stacks using these transforms to be solved without affine (e.g. rigid, similarity, translation...)