### PR TITLE
adding option to skip montage QC for lens corrected stack

### DIFF
--- a/rendermodules/mesh_lens_correction/do_mesh_lens_correction.py
+++ b/rendermodules/mesh_lens_correction/do_mesh_lens_correction.py
@@ -262,12 +262,13 @@ class MeshLensCorrection(RenderModule):
         # find the lens correction, write out to new stack
         meshclass.run()
 
-        # run montage qc on the new stack
-        qc_example = self.get_qc_example()
-        qc_mod = DetectMontageDefectsModule(
-                input_data=qc_example,
-                args=['--output_json', out_file.name])
-        qc_mod.run()
+        if self.args['do_montage_QC']:
+            # run montage qc on the new stack
+            qc_example = self.get_qc_example()
+            qc_mod = DetectMontageDefectsModule(
+                    input_data=qc_example,
+                    args=['--output_json', out_file.name])
+            qc_mod.run()
 
         try:
             self.output(

--- a/rendermodules/mesh_lens_correction/schemas.py
+++ b/rendermodules/mesh_lens_correction/schemas.py
@@ -64,6 +64,11 @@ class MeshLensCorrectionSchema(PointMatchOpenCVParameters):
         default=True,
         missing=True,
         description="Close input stack")
+    do_montage_QC = Bool(
+        required=False,
+        default=True,
+        missing=True,
+        description="perform montage QC on stack result")
     match_collection = Str(
         required=True,
         description="name of point match collection")


### PR DESCRIPTION
option to skip montage QC in mesh_lens_correction. something is hanging, this is an option just to skip it.
the montages have already past the good solve check at this point...
not ideal, but, a fast fix for some temca3 hold ups