### PR TITLE
fusion: add ability to skip nodes in stack DAG

### DIFF
--- a/rendermodules/fusion/fuse_stacks.py
+++ b/rendermodules/fusion/fuse_stacks.py
@@ -50,7 +50,7 @@ class FuseStacksModule(RenderModule):
     default_output_schema = FuseStacksOutput
 
     def fusetoparent(self, parent, child, transform=None,
-                     uninterpolated_zs=[]):
+                     interpolated_zs=None, uninterpolated_zs=[]):
         transform = ([renderapi.transform.AffineModel()]
                      if transform is None else transform)
         parent = child if parent is None else parent
@@ -60,7 +60,9 @@ class FuseStacksModule(RenderModule):
             renderapi.stack.get_z_values_for_stack, parent))
         child_zs = set(self.render.run(
             renderapi.stack.get_z_values_for_stack, child))
-        z_intersection = sorted(parent_zs.intersection(child_zs))
+        z_intersection = sorted((
+            parent_zs.intersection(child_zs) if interpolated_zs is None
+            else interpolated_zs))
 
         resolved_tspecs = []
         all_resolved_tform = []
@@ -81,43 +83,45 @@ class FuseStacksModule(RenderModule):
                 tilespecs=resolved_tspecs,
                 transformList=all_resolved_tform)
 
-        # can check order relation of child/parent stack
-        positive = max(child_zs) > z_intersection[-1]
-        self.logger.debug("positive concatenation? {}".format(positive))
+        if interpolated_zs:
+            # can check order relation of child/parent stack
+            positive = max(child_zs) > z_intersection[-1]
+            self.logger.debug("positive concatenation? {}".format(positive))
 
-        # generate jsonfiles representing interpolated overlapping tiles
-        for i, z in enumerate((
-                z_intersection if positive else z_intersection[::-1])):
-            section_tiles = []
-            lambda_ = float(i / float(len(z_intersection)))
+            # generate jsonfiles representing interpolated overlapping tiles
+            for i, z in enumerate((
+                    z_intersection if positive else z_intersection[::-1])):
+                section_tiles = []
+                lambda_ = float(i / float(len(z_intersection)))
 
-            p_resolved = renderapi.resolvedtiles.get_resolved_tiles_from_z(
-                parent, z, render=self.render)
-            c_resolved = renderapi.resolvedtiles.get_resolved_tiles_from_z(
-                child, z, render=self.render)
+                p_resolved = renderapi.resolvedtiles.get_resolved_tiles_from_z(
+                    parent, z, render=self.render)
+                c_resolved = renderapi.resolvedtiles.get_resolved_tiles_from_z(
+                    child, z, render=self.render)
 
-            all_resolved_tform += p_resolved.transforms + c_resolved.transforms
+                all_resolved_tform += (p_resolved.transforms +
+                                       c_resolved.transforms)
 
-            atiles = {ts.tileId: ts for ts
-                      in p_resolved.tilespecs}
-            btiles = {ts.tileId: ts for ts
-                      in c_resolved.tilespecs}
-            # generate interpolated tiles for intersection of set of tiles
-            for tileId in viewkeys(atiles) & viewkeys(btiles):
-                a = atiles[tileId]
-                interp_tile = copy.deepcopy(a)
-                b = btiles[tileId]
-                # b.tforms.append(transform) # TODO for nonconcat
-                b.tforms.extend(transform[::-1])
-                a.tforms.extend(transform[:-1][::-1])
+                atiles = {ts.tileId: ts for ts
+                          in p_resolved.tilespecs}
+                btiles = {ts.tileId: ts for ts
+                          in c_resolved.tilespecs}
+                # generate interpolated tiles for intersection of set of tiles
+                for tileId in viewkeys(atiles) & viewkeys(btiles):
+                    a = atiles[tileId]
+                    interp_tile = copy.deepcopy(a)
+                    b = btiles[tileId]
+                    # b.tforms.append(transform) # TODO for nonconcat
+                    b.tforms.extend(transform[::-1])
+                    a.tforms.extend(transform[:-1][::-1])
 
-                interp_tile.tforms = [
-                    renderapi.transform.InterpolatedTransform(
-                        a=renderapi.transform.TransformList(a.tforms),
-                        b=renderapi.transform.TransformList(b.tforms),
-                        lambda_=lambda_)]
-                section_tiles.append(interp_tile)
-                resolved_tspecs.append(interp_tile)
+                    interp_tile.tforms = [
+                        renderapi.transform.InterpolatedTransform(
+                            a=renderapi.transform.TransformList(a.tforms),
+                            b=renderapi.transform.TransformList(b.tforms),
+                            lambda_=lambda_)]
+                    section_tiles.append(interp_tile)
+                    resolved_tspecs.append(interp_tile)
         resolved_tforms = list(
             {tform.transformId: tform
              for tform in all_resolved_tform}.values())
@@ -125,7 +129,7 @@ class FuseStacksModule(RenderModule):
             tilespecs=resolved_tspecs, transformList=resolved_tforms)
 
     def fuse_graph(self, node, parentstack=None, inputtransform=None,
-                   create_nonoverlapping_zs=False,
+                   fuse_parent=False, create_nonoverlapping_zs=False,
                    max_tilespecs_per_group=5000):
         inputtransform = ([]
                           if inputtransform is None else inputtransform)
@@ -150,32 +154,37 @@ class FuseStacksModule(RenderModule):
                     c['stack'], render=self.render)
                 for c in node['children']) for zval in zlist}
             if len(node['children']) else {})
+        interpolated_zs = nodezs.intersection(parentzs)
         uninterpolated_zs = nodezs.difference(parentzs).difference(childzs)
 
-        # generate and upload interpolated tiles
-        resolvedtiles = self.fusetoparent(
-            parentstack, node['stack'],
-            uninterpolated_zs=uninterpolated_zs,
-            transform=node_tformlist)
+        # only get interpolation/import if "fuse_stack" option is true
+        if node.get("fuse_stack"):
+            # generate and upload interpolated tiles
+            resolvedtiles = self.fusetoparent(
+                parentstack, node['stack'],
+                interpolated_zs=(interpolated_zs if fuse_parent else set([])),
+                uninterpolated_zs=uninterpolated_zs,
+                transform=node_tformlist)
 
-        if self.args['output_stack'] not in self.render.run(
-                renderapi.render.get_stacks_by_owner_project):
-            renderapi.stack.create_stack(
-                self.args['output_stack'], render=self.render)
-        self.render.run(renderapi.stack.set_stack_state,
-                        self.args['output_stack'], 'LOADING')
+            if self.args['output_stack'] not in self.render.run(
+                    renderapi.render.get_stacks_by_owner_project):
+                renderapi.stack.create_stack(
+                    self.args['output_stack'], render=self.render)
+            self.render.run(renderapi.stack.set_stack_state,
+                            self.args['output_stack'], 'LOADING')
 
-        renderapi.client.import_tilespecs_parallel(
-            self.args['output_stack'], resolvedtiles.tilespecs,
-            resolvedtiles.transforms, pool_size=self.args['pool_size'],
-            close_stack=False,
-            max_tilespecs_per_group=max_tilespecs_per_group,
-            render=self.render)
+            renderapi.client.import_tilespecs_parallel(
+                self.args['output_stack'], resolvedtiles.tilespecs,
+                resolvedtiles.transforms, pool_size=self.args['pool_size'],
+                close_stack=False,
+                max_tilespecs_per_group=max_tilespecs_per_group,
+                render=self.render)
 
         # recurse through depth of graph
         for child in node['children']:
             self.fuse_graph(
                 child, parentstack=node['stack'],
+                fuse_parent=node['fuse_stack'],
                 inputtransform=node_tformlist)
 
     def run(self):

--- a/rendermodules/fusion/schemas.py
+++ b/rendermodules/fusion/schemas.py
@@ -16,6 +16,8 @@ class Stack(argschema.schemas.DefaultSchema):
     stack = Str(required=True)
     transform = Nested(Transform, required=False)
     children = Nested("self", many=True)
+    fuse_stack = Bool(required=False, default=True, description=(
+        "whether to include this stack's in the output of fusion"))
 
 
 # register adjacent schemas


### PR DESCRIPTION
This implements a "fuse_stack" option on the stack objects in the fusion graph, allowing the zs within an input stack to be skipped in the case of only wanting to write out a subset of the nodes.  This should also allow the workflow to build out fusions without interpolated transforms by repeatedly calling this with all but the leaf transforms missing.