### PR TITLE
bumping EMaligner, adding test for finer control of polynomial regula…

### DIFF
--- a/integration_tests/test_solver.py
+++ b/integration_tests/test_solver.py
@@ -91,3 +91,8 @@ def test_solver_montage_test(render, montage_pointmatches, raw_stack, tmpdir):
     # for poly_order=2, similar regularizations work
     # for poly_order > 2, need to tweak regularization
     one_solve(parameters, precision=1e-3)
+
+    parameters['transformation'] = "Polynomial2DTransform"
+    parameters['poly_order'] = 2
+    parameters['regularization']['poly_factors'] = [1e-5, 1.0, 1e6]
+    one_solve(parameters, precision=1e-3)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ scipy
 rtree
 networkx
 bokeh
-EMaligner==0.3.1
+EMaligner==0.3.2
 matplotlib
 opencv-contrib-python<3.4.3.0
 jinja2


### PR DESCRIPTION
…rization

EMaligner now has finer tuned control for polynomial parameter regularization.
For example, for 2nd order polynomial, a regularization.poly_factors list of 
`[1e-5, 1.0, 1e6]` specifies factors for 0th, 1st, and 2nd order parameters respectively.
Each of these are multiplied by regularization.default.lambda, keeping with tradition of having default_lambda and translation_factor for affine, which is equivalent to a 1st order polynomial with poly_factors `[translation_factor, default_lambda]`

The purpose is to add some higher constraint to the 2nd order parameters, as, for poorly matched point matches, these parameters can get large enough to drastically distort a tile, usually resin or blood vessel. Specifying something like 1e6 prevents these higher order corrections from becoming too powerful.