### PR TITLE
Overwrite montage scape section

### DIFF
--- a/integration_tests/test_rough_align.py
+++ b/integration_tests/test_rough_align.py
@@ -245,12 +245,19 @@ def montage_z_mapped_stack(render, montage_stack, downsample_sections_dir):
         assert(z in zvalues)
 
     # check for overwrite = False
-    params['overwrite_z'] = False
-    params['zstart'] = 1022
-    params['zend'] = 1022
-    params['new_z_start'] = 253
-
-    mod = MakeMontageScapeSectionStack(input_data=params, args=['--output_json', outjson])
+    params1 = {
+        "render": render_params,
+        "montage_stack": montage_stack,
+        "output_stack": output_stack,
+        "image_directory": downsample_sections_dir,
+        "imgformat": "png",
+        "scale": 0.1,
+        "zstart": 1022,
+        "zend": 1022,
+        "set_new_z": True,
+        "new_z_start": 253
+    }
+    mod = MakeMontageScapeSectionStack(input_data=params1, args=['--output_json', outjson])
     mod.run()
 
     zvalues = render.run(renderapi.stack.get_z_values_for_stack, output_stack)

--- a/integration_tests/test_rough_align.py
+++ b/integration_tests/test_rough_align.py
@@ -279,7 +279,7 @@ def montage_z_mapped_stack(render, montage_stack, downsample_sections_dir):
         "set_new_z": False,
         "new_z_start": 253
     }
-    mod = MakeMontageScapeSectionStack(input_data=params1, args=['--output_json', outjson])
+    mod = MakeMontageScapeSectionStack(input_data=params2, args=['--output_json', outjson])
     mod.run()
 
     zvalues = render.run(renderapi.stack.get_z_values_for_stack, output_stack)

--- a/integration_tests/test_rough_align.py
+++ b/integration_tests/test_rough_align.py
@@ -266,6 +266,28 @@ def montage_z_mapped_stack(render, montage_stack, downsample_sections_dir):
     for z in zs:
         assert(z in zvalues)
 
+    params2 = {
+        "render": render_params,
+        "montage_stack": montage_stack,
+        "output_stack": output_stack,
+        "image_directory": downsample_sections_dir,
+        "overwrite_zlayer": True,
+        "imgformat": "png",
+        "scale": 0.1,
+        "zstart": 253,
+        "zend": 253,
+        "set_new_z": False,
+        "new_z_start": 253
+    }
+    mod = MakeMontageScapeSectionStack(input_data=params1, args=['--output_json', outjson])
+    mod.run()
+
+    zvalues = render.run(renderapi.stack.get_z_values_for_stack, output_stack)
+    zs = [251, 252, 253]
+
+    for z in zs:
+        assert(z in zvalues)
+
     yield output_stack
     renderapi.stack.delete_stack(output_stack, render=render)
 

--- a/integration_tests/test_rough_align.py
+++ b/integration_tests/test_rough_align.py
@@ -276,14 +276,14 @@ def montage_z_mapped_stack(render, montage_stack, downsample_sections_dir):
         "scale": 0.1,
         "zstart": 1022,
         "zend": 1022,
-        "set_new_z": False,
+        "set_new_z": True,
         "new_z_start": 253
     }
     mod = MakeMontageScapeSectionStack(input_data=params2, args=['--output_json', outjson])
     mod.run()
 
     zvalues = render.run(renderapi.stack.get_z_values_for_stack, output_stack)
-    zs = [251, 252, 1022]
+    zs = [251, 252, 253]
 
     for z in zs:
         assert(z in zvalues)

--- a/integration_tests/test_rough_align.py
+++ b/integration_tests/test_rough_align.py
@@ -277,7 +277,8 @@ def montage_z_mapped_stack(render, montage_stack, downsample_sections_dir):
         "zstart": 1022,
         "zend": 1022,
         "set_new_z": True,
-        "new_z_start": 253
+        "new_z_start": 253,
+        "close_stack": True
     }
     mod = MakeMontageScapeSectionStack(input_data=params2, args=['--output_json', outjson])
     mod.run()

--- a/integration_tests/test_rough_align.py
+++ b/integration_tests/test_rough_align.py
@@ -230,7 +230,7 @@ def montage_z_mapped_stack(render, montage_stack, downsample_sections_dir):
         "imgformat": "png",
         "scale": 0.1,
         "zstart": 1020,
-        "zend": 1022,
+        "zend": 1021,
         "set_new_z": True,
         "new_z_start": 251
     }
@@ -239,7 +239,25 @@ def montage_z_mapped_stack(render, montage_stack, downsample_sections_dir):
     mod.run()
 
     zvalues = render.run(renderapi.stack.get_z_values_for_stack, output_stack)
+    zs = [251, 252]
+
+    for z in zs:
+        assert(z in zvalues)
+
+    # check for overwrite = False
+    params['overwrite_z'] = False
+    params['zstart'] = 1022
+    params['zend'] = 1022
+    params['new_z_start'] = 253
+
+    mod = MakeMontageScapeSectionStack(input_data=params, args=['--output_json', outjson])
+    mod.run()
+
+    zvalues = render.run(renderapi.stack.get_z_values_for_stack, output_stack)
     zs = [251, 252, 253]
+
+    for z in zs:
+        assert(z in zvalues)
 
     yield output_stack
     renderapi.stack.delete_stack(output_stack, render=render)
@@ -377,6 +395,7 @@ def test_montage_scape_stack(render, montage_scape_stack):
     zvalues = render.run(renderapi.stack.get_z_values_for_stack, montage_scape_stack)
     zs = [1020, 1021, 1022]
     assert(set(zvalues)==set(zs))
+
 '''
 def test_montage_scape_stack_code_coverage(render, montage_stack, downsample_sections_dir):
     output_stack = '{}_DS_code_coverage'.format(montage_stack)

--- a/integration_tests/test_rough_align.py
+++ b/integration_tests/test_rough_align.py
@@ -274,8 +274,8 @@ def montage_z_mapped_stack(render, montage_stack, downsample_sections_dir):
         "overwrite_zlayer": True,
         "imgformat": "png",
         "scale": 0.1,
-        "zstart": 253,
-        "zend": 253,
+        "zstart": 1022,
+        "zend": 1022,
         "set_new_z": False,
         "new_z_start": 253
     }
@@ -283,7 +283,7 @@ def montage_z_mapped_stack(render, montage_stack, downsample_sections_dir):
     mod.run()
 
     zvalues = render.run(renderapi.stack.get_z_values_for_stack, output_stack)
-    zs = [251, 252, 253]
+    zs = [251, 252, 1022]
 
     for z in zs:
         assert(z in zvalues)

--- a/rendermodules/dataimport/make_montage_scapes_stack.py
+++ b/rendermodules/dataimport/make_montage_scapes_stack.py
@@ -232,10 +232,6 @@ class MakeMontageScapeSectionStack(StackOutputModule):
                     renderapi.stack.delete_section(self.args['output_stack'], 
                                                    newz, 
                                                    render=self.render)
-                renderapi.stack.set_stack_state(self.args['output_stack'],
-                                                'COMPLETE',
-                                                render=self.render)
-
         
 
         # generate the tag string to add to output tilespec json file name
@@ -321,10 +317,11 @@ class MakeMontageScapeSectionStack(StackOutputModule):
                         self.output_stack,
                         jsonfiles)
 
-        # set stack state to complete
-        self.render.run(renderapi.stack.set_stack_state,
-                        self.output_stack,
-                        state='COMPLETE')
+        if self.close_stack:
+            # set stack state to complete
+            self.render.run(renderapi.stack.set_stack_state,
+                            self.output_stack,
+                            state='COMPLETE')
 
         self.output({'output_stack': self.output_stack})
 

--- a/rendermodules/dataimport/make_montage_scapes_stack.py
+++ b/rendermodules/dataimport/make_montage_scapes_stack.py
@@ -222,10 +222,7 @@ class MakeMontageScapeSectionStack(StackOutputModule):
                             self.args['output_stack'],
                             render=self.render)
             
-            if self.args['overwrite_z'] is False:
-                # do not include those sections that are already in the output stack
-                Z = [[int(oldz), int(newz)] for oldz, newz in zip(zvalues, newzvalues) if not(float(newz) in outzvalues)]
-            else:
+            if self.overwrite_zlayer:
                 # stack has to be in loading state
                 renderapi.stack.set_stack_state(self.args['output_stack'],
                                                 'LOADING',

--- a/rendermodules/dataimport/schemas.py
+++ b/rendermodules/dataimport/schemas.py
@@ -139,6 +139,11 @@ class MakeMontageScapeSectionStackParameters(OutputStackParameters):
         default=False,
         missing=False,
         metadata={'description':'Do you want to scale the downsample to the size of section? Default = False'})
+    overwrite_z = Boolean(
+        required=False,
+        default=True,
+        missing=True,
+        metadata={'description': 'overwrite existing section in stack (Default = True'})
     doFilter = Boolean(required=False, default=True, description=(
         "whether to apply default filtering when generating "
         "missing downsamples"))

--- a/rendermodules/dataimport/schemas.py
+++ b/rendermodules/dataimport/schemas.py
@@ -139,11 +139,6 @@ class MakeMontageScapeSectionStackParameters(OutputStackParameters):
         default=False,
         missing=False,
         metadata={'description':'Do you want to scale the downsample to the size of section? Default = False'})
-    overwrite_z = Boolean(
-        required=False,
-        default=True,
-        missing=True,
-        metadata={'description': 'overwrite existing section in stack (Default = True'})
     doFilter = Boolean(required=False, default=True, description=(
         "whether to apply default filtering when generating "
         "missing downsamples"))


### PR DESCRIPTION
Functionality to overwrite existing Z in montage scape stack. This avoids multiple tiles in same Z issue on re-runs. 