### PR TITLE
Temp montage stack fix

### DIFF
--- a/integration_tests/test_rough_align.py
+++ b/integration_tests/test_rough_align.py
@@ -558,7 +558,7 @@ def test_render_downsample_with_mipmaps(render, one_tile_montage, tmpdir_factory
     # generate tilespecs used for rendering stack input
     maxlvl = 1
     tspecs = create_tilespecs_without_mipmaps(render, ex['input_stack'], maxlvl, 1020)
-    ts_levels = {int(i) for l in (ts.ip.levels) for ts in tspecs.tilespecs) for i in l}
+    ts_levels = {int(i) for l in (ts.ip.levels for ts in tspecs.tilespecs) for i in l}
     #ts_levels = {int(i) for l in (ts.ip.levels for ts in tspecs) for i in l}
     # levels > maxlevel should not be included if
     assert not ts_levels.difference(set(range(maxlvl + 1)))

--- a/integration_tests/test_rough_align.py
+++ b/integration_tests/test_rough_align.py
@@ -609,13 +609,13 @@ def test_render_downsample_with_mipmaps(render, one_tile_montage, tmpdir_factory
         assert(1021 not in zvalues)
 
 
-def make_montage_stack_without_downsamples(render, one_tile_montage, tmpdir_factory):
+def make_montage_stack_without_downsamples(render, montage_stack, tmpdir_factory):
     # testing for make montage scape stack without having downsamples generated
     tmp_dir = str(tmpdir_factory.mktemp('downsample'))
     output_stack = '{}_Downsample'.format(one_tile_montage)
     params = {
         "render": render_params,
-        "montage_stack": one_tile_montage,
+        "montage_stack": montage_stack,
         "output_stack": output_stack,
         "image_directory": tmp_dir,
         "imgformat": "png",
@@ -651,13 +651,13 @@ def make_montage_stack_without_downsamples(render, one_tile_montage, tmpdir_fact
 
 
 def test_make_montage_stack_module_without_downsamples(
-        render, one_tile_montage, tmpdir_factory):
+        render, montage_stack, tmpdir_factory):
     # testing for make montage scape stack without having downsamples generated
     tmp_dir = str(tmpdir_factory.mktemp('downsample'))
-    output_stack = '{}_Downsample'.format(one_tile_montage)
+    output_stack = '{}_Downsample'.format(montage_stack)
     params = {
         "render": render_params,
-        "montage_stack": one_tile_montage,
+        "montage_stack": montage_stack,
         "output_stack": output_stack,
         "image_directory": tmp_dir,
         "imgformat": "png",

--- a/integration_tests/test_rough_align.py
+++ b/integration_tests/test_rough_align.py
@@ -558,7 +558,8 @@ def test_render_downsample_with_mipmaps(render, one_tile_montage, tmpdir_factory
     # generate tilespecs used for rendering stack input
     maxlvl = 1
     tspecs = create_tilespecs_without_mipmaps(render, ex['input_stack'], maxlvl, 1020)
-    ts_levels = {int(i) for l in (ts.ip.levels for ts in tspecs) for i in l}
+    ts_levels = {int(i) for l in (ts.ip.levels) for ts in tspecs.tilespecs) for i in l}
+    #ts_levels = {int(i) for l in (ts.ip.levels for ts in tspecs) for i in l}
     # levels > maxlevel should not be included if
     assert not ts_levels.difference(set(range(maxlvl + 1)))
 

--- a/rendermodules/materialize/render_downsample_sections.py
+++ b/rendermodules/materialize/render_downsample_sections.py
@@ -57,12 +57,14 @@ def check_stack_for_mipmaps(render, input_stack, zvalues):
 
 def create_tilespecs_without_mipmaps(render, montage_stack, level, z):
     """return tilespecs missing mipmaplevels above the specified level"""
-    ts = render.run(renderapi.tilespec.get_tile_specs_from_z, montage_stack, z)
-    for t in ts:
+    ts = render.run(renderapi.resolvedtiles.get_resolved_tiles_from_z, montage_stack, z)
+    for t in ts.tilespecs:
         t.ip = renderapi.tilespec.ImagePyramid({
             lvl: mipmap for lvl, mipmap in t.ip.items()
             if int(lvl) <= int(level)})
+    
     return ts
+
 
 
 # FIXME this should be provided in render-python external
@@ -96,6 +98,7 @@ class RenderSectionAtScale(RenderModule):
 
         ds_source = input_stack
         # check if there are mipmaps in this stack
+        temp_no_mipmap_stack = "" # this needs initialization here for the delete to work
         if stack_has_mipmaps:
             print("stack has mipmaps")
             # clone the input stack to a temporary one with level 1 mipmap alone
@@ -105,12 +108,15 @@ class RenderSectionAtScale(RenderModule):
 
             mypartial = partial(create_tilespecs_without_mipmaps,
                                 render, input_stack, level)
-
+            
             with poolclass(pool_size) as pool:
-                # jsonfiles = pool.map(mypartial, zvalues)
-                all_tilespecs = [i for l in pool.map(mypartial, zvalues)
-                                 for i in l]
+                all_resolved_ts = pool.map(mypartial, zvalues)
 
+            #with poolclass(pool_size) as pool:
+            #    # jsonfiles = pool.map(mypartial, zvalues)
+            #    all_tilespecs = [i for l in pool.map(mypartial, zvalues)
+            #                     for i in l]
+            
             # create stack - overwrites existing one
             render.run(renderapi.stack.create_stack, temp_no_mipmap_stack)
 
@@ -118,12 +124,16 @@ class RenderSectionAtScale(RenderModule):
             render.run(renderapi.stack.set_stack_state,
                        temp_no_mipmap_stack, state='LOADING')
 
-            render.run(renderapi.client.import_tilespecs_parallel,
-                       temp_no_mipmap_stack,
-                       all_tilespecs,
-                       poolsize=pool_size,
-                       close_stack=True,
-                       mpPool=poolclass)
+            #render.run(renderapi.client.import_tilespecs_parallel,
+            #           temp_no_mipmap_stack,
+            #           all_tilespecs,
+            #           poolsize=pool_size,
+            #           close_stack=True,
+            #           mpPool=poolclass)
+            for rtspecs in all_resolved_ts:
+                render.run(renderapi.resolvedtiles.put_tilespecs,
+                           temp_no_mipmap_stack,
+                           resolved_tiles=rtspecs)
             ds_source = temp_no_mipmap_stack
 
         render.run(renderapi.client.renderSectionClient,

--- a/rendermodules/materialize/render_downsample_sections.py
+++ b/rendermodules/materialize/render_downsample_sections.py
@@ -112,10 +112,6 @@ class RenderSectionAtScale(RenderModule):
             with poolclass(pool_size) as pool:
                 all_resolved_ts = pool.map(mypartial, zvalues)
 
-            #with poolclass(pool_size) as pool:
-            #    # jsonfiles = pool.map(mypartial, zvalues)
-            #    all_tilespecs = [i for l in pool.map(mypartial, zvalues)
-            #                     for i in l]
             
             # create stack - overwrites existing one
             render.run(renderapi.stack.create_stack, temp_no_mipmap_stack)
@@ -123,17 +119,13 @@ class RenderSectionAtScale(RenderModule):
             # set stack state to LOADING
             render.run(renderapi.stack.set_stack_state,
                        temp_no_mipmap_stack, state='LOADING')
-
-            #render.run(renderapi.client.import_tilespecs_parallel,
-            #           temp_no_mipmap_stack,
-            #           all_tilespecs,
-            #           poolsize=pool_size,
-            #           close_stack=True,
-            #           mpPool=poolclass)
+        
             for rtspecs in all_resolved_ts:
-                render.run(renderapi.resolvedtiles.put_tilespecs,
+                render.run(renderapi.client.import_tilespecs_parallel,
                            temp_no_mipmap_stack,
-                           resolved_tiles=rtspecs)
+                           rtspecs.tilespecs,
+                           sharedTransforms=rtspecs.transforms)
+            
             ds_source = temp_no_mipmap_stack
 
         render.run(renderapi.client.renderSectionClient,


### PR DESCRIPTION
Fixing make montage scape stack module.
1. Deletes temp stack at the end (already existing feature with a bug that was fixed)
2. Creating the temp stack with refIds so as to save space in mongo db