### PR TITLE
Downsample masks

### DIFF
--- a/integration_tests/test_data.py
+++ b/integration_tests/test_data.py
@@ -244,6 +244,18 @@ test_rough_parameters = render_json_template(
         firstz=1020,
         lastz=1022)
 
+rough_solver_example = render_json_template(
+        example_env, 'solver_montage_test.json',
+        render_project = rough_project,
+        render_host=render_host,
+        render_owner=render_test_owner,
+        render_port=render_port,
+        mongo_port=os.environ.get('MONGO_PORT', 27017),
+        render_mongo_host=os.environ.get('RENDER_MONGO_HOST', 'localhost'),
+        render_output_owner=render_test_owner,
+        render_client_scripts=client_script_location,
+        solver_output_dir=tempfile.mkdtemp())
+
 test_rough_parameters_python = render_json_template(
         example_env,
         'rough_align_python_input.json',

--- a/integration_tests/test_data.py
+++ b/integration_tests/test_data.py
@@ -3,7 +3,7 @@ from jinja2 import Environment, FileSystemLoader
 import json
 import tempfile
 
-pool_size = os.environ.get('RENDERMODULES_POOL_SIZE',5)
+pool_size = os.environ.get('RENDERMODULES_POOL_SIZE', 5)
 
 render_host = os.environ.get(
     'RENDER_HOST', 'renderservice')
@@ -19,7 +19,7 @@ client_script_location = os.environ.get(
 
 # rendermodules test compares with integer
 try:
-    render_port=int(render_port)
+    render_port = int(render_port)
 except ValueError:
     pass
 
@@ -39,8 +39,13 @@ try:
 except OSError as e:
     pass
 
+TEST_DATA_ROOT = os.environ.get(
+    'RENDER_TEST_DATA_ROOT',
+    '/allen/aibs/pipeline/image_processing/volume_assembly')
+
 log_dir = os.environ.get(
-    'LOG_DIR', '/allen/aibs/pipeline/image_processing/volume_assembly/logs/')
+    'LOG_DIR',
+    os.path.join(TEST_DATA_ROOT, 'logs'))
 
 try:
     os.makedirs(log_dir)
@@ -50,16 +55,17 @@ except OSError as e:
 example_dir = os.path.join(os.path.dirname(__file__), 'test_files')
 example_env = Environment(loader=FileSystemLoader(example_dir))
 
-TEST_DATA_ROOT = os.environ.get(
-    'RENDER_TEST_DATA_ROOT', '/allen/aibs/pipeline/image_processing/volume_assembly')
 
 FIJI_PATH = os.environ.get(
-    'FIJI_PATH', '/allen/aibs/pipeline/image_processing/volume_assembly/Fiji.app')
+    'FIJI_PATH',
+    os.path.join(TEST_DATA_ROOT, 'Fiji.app'))
 
 
-#ROUGH_SOLVER_EXECUTABLE = os.environ.get(
-#    'ROUGH_SOLVER_EXECUTABLE',
-#    '/allen/aibs/pipeline/image_processing/volume_assembly/EM_aligner/matlab_compiled/do_rough_alignment')
+# ROUGH_SOLVER_EXECUTABLE = os.environ.get(
+#         'ROUGH_SOLVER_EXECUTABLE',
+#         os.path.join(
+#             TEST_DATA_ROOT,
+#             'EM_aligner/matlab_compiled/do_rough_alignment'))
 
 
 def render_json_template(env, template_file, **kwargs):
@@ -72,34 +78,50 @@ def render_json_template(env, template_file, **kwargs):
 METADATA_FILE = os.path.join(example_dir, 'TEMCA_mdfile.json')
 
 MIPMAP_TILESPECS_JSON = render_json_template(
-    example_env, 'mipmap_tilespecs_ref.json', test_data_root=TEST_DATA_ROOT)
+        example_env,
+        'mipmap_tilespecs_ref.json',
+        test_data_root=TEST_DATA_ROOT)
 MIPMAP_TRANSFORMS_JSON = render_json_template(
-    example_env, 'mipmap_ref_tforms.json', test_data_root=TEST_DATA_ROOT)
+        example_env,
+        'mipmap_ref_tforms.json',
+        test_data_root=TEST_DATA_ROOT)
 
-cons_ex_tilespec_json = render_json_template(example_env, 'cycle1_step1_acquire_tiles.json',
-                                             test_data_root=TEST_DATA_ROOT)
+cons_ex_tilespec_json = render_json_template(
+        example_env,
+        'cycle1_step1_acquire_tiles.json',
+        test_data_root=TEST_DATA_ROOT)
 
-cons_ex_transform_json = render_json_template(example_env,  'cycle1_step1_acquire_transforms.json',
-                                              test_data_root=TEST_DATA_ROOT)
+cons_ex_transform_json = render_json_template(
+        example_env,
+        'cycle1_step1_acquire_transforms.json',
+        test_data_root=TEST_DATA_ROOT)
 
 multiplicative_correction_example_dir = os.path.join(
     TEST_DATA_ROOT, 'intensitycorrection_test_data')
 
-MULTIPLICATIVE_INPUT_JSON = render_json_template(example_env, 'intensity_correction_template.json',
-                                                 test_data_root=TEST_DATA_ROOT)
+MULTIPLICATIVE_INPUT_JSON = render_json_template(
+        example_env,
+        'intensity_correction_template.json',
+        test_data_root=TEST_DATA_ROOT)
 # lc_example_dir = os.environ.get('RENDER_MODULES_LC_TEST_DATA',
 #     'allen/aibs/pipeline/image_processing/volume_assembly/lc_test_data/')
 
 
-calc_lens_parameters = render_json_template(example_env, 'calc_lens_correction_parameters.json',
-                                            test_data_root=TEST_DATA_ROOT,
-                                            fiji_path=FIJI_PATH,
-                                            test_output=tempfile.mkdtemp())
+calc_lens_parameters = render_json_template(
+        example_env,
+        'calc_lens_correction_parameters.json',
+        test_data_root=TEST_DATA_ROOT,
+        fiji_path=FIJI_PATH,
+        test_output=tempfile.mkdtemp())
 
-TILESPECS_NO_LC_JSON = render_json_template(example_env, 'test_noLC.json',
-                                            test_data_root=TEST_DATA_ROOT)
-TILESPECS_LC_JSON = render_json_template(example_env, 'test_LC.json',
-                                         test_data_root=TEST_DATA_ROOT)
+TILESPECS_NO_LC_JSON = render_json_template(
+        example_env,
+        'test_noLC.json',
+        test_data_root=TEST_DATA_ROOT)
+TILESPECS_LC_JSON = render_json_template(
+        example_env,
+        'test_LC.json',
+        test_data_root=TEST_DATA_ROOT)
 
 # materialization testing
 MATERIALIZE_BOX_JSON = render_json_template(
@@ -115,62 +137,74 @@ swap_pt_matches1 = render_json_template(example_env, 'swap_pt_matches1.json')
 
 swap_pt_matches2 = render_json_template(example_env, 'swap_pt_matches2.json')
 
-RAW_STACK_INPUT_JSON = render_json_template(example_env, 'raw_tile_specs_for_em_montage.json',
-                                            test_data_root=TEST_DATA_ROOT)
+RAW_STACK_INPUT_JSON = render_json_template(
+        example_env,
+        'raw_tile_specs_for_em_montage.json',
+        test_data_root=TEST_DATA_ROOT)
 
-MATLAB_SOLVER_PATH = os.environ.get('MATLAB_SOLVER_PATH',
-    '/allen/aibs/pipeline/image_processing/volume_assembly/EMAligner/dev/allen_templates')
+MATLAB_SOLVER_PATH = os.environ.get(
+        'MATLAB_SOLVER_PATH',
+        os.path.join(TEST_DATA_ROOT, 'EMAligner/dev/allen_templates'))
 
-MONTAGE_SOLVER_BIN = os.path.join(MATLAB_SOLVER_PATH,'run_em_solver.sh')
+MONTAGE_SOLVER_BIN = os.path.join(MATLAB_SOLVER_PATH, 'run_em_solver.sh')
 RENDER_SPARK_JAR = os.environ['RENDER_SPARK_JAR']
-SPARK_HOME = os.environ.get('SPARK_HOME','/shared/spark')
+SPARK_HOME = os.environ.get('SPARK_HOME', '/shared/spark')
 montage_project = "em_montage_test"
 montage_collection = "test_montage_collection"
 montage_z = 1015
-log4propertiesfile = os.environ.get("SPARK_LOG_PROPERTIES",
-    "/allen/aibs/pipeline/image_processing/volume_assembly/utils/spark/conf/log4j.properties.template")
-pbs_template=os.environ.get("PBS_TEMPLATE",
-    "/allen/aibs/pipeline/image_processing/volume_assembly/utils/code/spark_submit/spinup_spark.pbs")
+log4propertiesfile = os.environ.get(
+        "SPARK_LOG_PROPERTIES",
+        os.path.join(
+            TEST_DATA_ROOT,
+            'utils/spark/conf/log4j.properties.template'))
+pbs_template = os.environ.get(
+        "PBS_TEMPLATE",
+        os.path.join(
+            TEST_DATA_ROOT,
+            'utils/code/spark_submit/spinup_spark.pbs'))
 
-test_pointmatch_parameters = render_json_template(example_env,
-    'point_match_parameters.json',
-    render_host = render_host,
-    render_port = render_port,
-    render_project = montage_project,
-    render_owner = render_test_owner,
-    render_client_scripts = client_script_location,
-    spark_log_dir = tempfile.mkdtemp(),
-    render_spark_jar = RENDER_SPARK_JAR,
-    spark_master_url = os.environ['SPARK_MASTER_URL'],
-    spark_home = SPARK_HOME,
-    point_match_collection = montage_collection,
-    spark_logging_properties = log4propertiesfile)
+test_pointmatch_parameters = render_json_template(
+        example_env,
+        'point_match_parameters.json',
+        render_host=render_host,
+        render_port=render_port,
+        render_project=montage_project,
+        render_owner=render_test_owner,
+        render_client_scripts=client_script_location,
+        spark_log_dir=tempfile.mkdtemp(),
+        render_spark_jar=RENDER_SPARK_JAR,
+        spark_master_url=os.environ['SPARK_MASTER_URL'],
+        spark_home=SPARK_HOME,
+        point_match_collection=montage_collection,
+        spark_logging_properties=log4propertiesfile)
 
-test_pointmatch_parameters_qsub = render_json_template(example_env,
-    'point_match_parameters_qsub.json',
-    render_host = render_host,
-    render_port = render_port,
-    render_project = montage_project,
-    render_owner = render_test_owner,
-    render_client_scripts = client_script_location,
-    spark_log_dir = tempfile.mkdtemp(),
-    render_spark_jar = RENDER_SPARK_JAR,
-    spark_home = SPARK_HOME,
-    point_match_collection = montage_collection,
-    spark_logging_properties = log4propertiesfile,
-    pbs_template=pbs_template)
+test_pointmatch_parameters_qsub = render_json_template(
+        example_env,
+        'point_match_parameters_qsub.json',
+        render_host=render_host,
+        render_port=render_port,
+        render_project=montage_project,
+        render_owner=render_test_owner,
+        render_client_scripts=client_script_location,
+        spark_log_dir=tempfile.mkdtemp(),
+        render_spark_jar=RENDER_SPARK_JAR,
+        spark_home=SPARK_HOME,
+        point_match_collection=montage_collection,
+        spark_logging_properties=log4propertiesfile,
+        pbs_template=pbs_template)
 
-test_em_montage_parameters = render_json_template(example_env,
-    'run_montage_job_for_section_template.json',
-    render_host = render_host,
-    render_port = render_port,
-    render_project = montage_project,
-    render_owner = render_test_owner,
-    render_client_scripts = client_script_location,
-    em_solver_bin = MONTAGE_SOLVER_BIN,
-    scratch_dir = tempfile.mkdtemp(),
-    point_match_collection = montage_collection,
-    montage_z = montage_z)
+test_em_montage_parameters = render_json_template(
+        example_env,
+        'run_montage_job_for_section_template.json',
+        render_host=render_host,
+        render_port=render_port,
+        render_project=montage_project,
+        render_owner=render_test_owner,
+        render_client_scripts=client_script_location,
+        em_solver_bin=MONTAGE_SOLVER_BIN,
+        scratch_dir=tempfile.mkdtemp(),
+        point_match_collection=montage_collection,
+        montage_z=montage_z)
 
 # rough alignment parameters' data
 ROUGH_MONTAGE_TILESPECS_JSON = render_json_template(
@@ -180,51 +214,46 @@ ROUGH_MONTAGE_TRANSFORM_JSON = render_json_template(
     example_env, 'rough_align_montage_ref_transforms.json',
     test_data_root=TEST_DATA_ROOT)
 
-ROUGH_DS_TEST_TILESPECS_JSON = render_json_template(example_env, 'rough_align_downsample_test_tilespecs.json',
-                                                    test_data_root=TEST_DATA_ROOT)
+ROUGH_DS_TEST_TILESPECS_JSON = render_json_template(
+        example_env,
+        'rough_align_downsample_test_tilespecs.json',
+        test_data_root=TEST_DATA_ROOT)
 
-ROUGH_POINT_MATCH_COLLECTION = render_json_template(example_env, 'rough_align_point_matches.json')
+ROUGH_POINT_MATCH_COLLECTION = render_json_template(
+        example_env, 'rough_align_point_matches.json')
 
-ROUGH_MAPPED_PT_MATCH_COLLECTION = render_json_template(example_env, 'rough_align_mapped_point_matches.json')
+ROUGH_MAPPED_PT_MATCH_COLLECTION = render_json_template(
+        example_env, 'rough_align_mapped_point_matches.json')
 
 rough_project = "rough_align_test"
 
-ROUGH_MASK_DIR = '/allen/aibs/pipeline/image_processing/volume_assembly/em_modules_test_data/rough_align_test_data/masks'
+ROUGH_MASK_DIR = os.path.join(
+        TEST_DATA_ROOT,
+        'em_modules_test_data/rough_align_test_data/masks')
 
-test_rough_parameters = render_json_template(example_env,
-    'run_rough_job_for_chunk_template.json',
-    render_host = render_host,
-    render_port = render_port,
-    render_project = rough_project,
-    render_owner = render_test_owner,
-    render_client_scripts = client_script_location,
-    em_solver_bin = MONTAGE_SOLVER_BIN,
-    scratch_dir = tempfile.mkdtemp(),
-    firstz = 1020,
-    lastz = 1022
-    )
+test_rough_parameters = render_json_template(
+        example_env,
+        'run_rough_job_for_chunk_template.json',
+        render_host=render_host,
+        render_port=render_port,
+        render_project=rough_project,
+        render_owner=render_test_owner,
+        render_client_scripts=client_script_location,
+        em_solver_bin=MONTAGE_SOLVER_BIN,
+        scratch_dir=tempfile.mkdtemp(),
+        firstz=1020,
+        lastz=1022)
 
-rough_solver_example = render_json_template(example_env, 'solver_montage_test.json',
-                                            render_project = rough_project,
-                                            render_host=render_host,
-                                            render_owner=render_test_owner,
-                                            render_port=render_port,
-                                            mongo_port=os.environ.get('MONGO_PORT', 27017),
-                                            render_mongo_host=os.environ.get('RENDER_MONGO_HOST', 'localhost'),
-                                            render_output_owner=render_test_owner,
-                                            render_client_scripts=client_script_location,
-                                            solver_output_dir=tempfile.mkdtemp())
-
-test_rough_parameters_python = render_json_template(example_env,
-    'rough_align_python_input.json',
-    render_host = render_host,
-    render_port = render_port,
-    render_project = rough_project,
-    render_owner = render_test_owner,
-    render_client_scripts = client_script_location,
-    firstz = 1020,
-    lastz = 1022
-    )
+test_rough_parameters_python = render_json_template(
+        example_env,
+        'rough_align_python_input.json',
+        render_host=render_host,
+        render_port=render_port,
+        render_project=rough_project,
+        render_owner=render_test_owner,
+        render_client_scripts=client_script_location,
+        firstz=1020,
+        lastz=1022)
 
 
 apply_rough_alignment_example = {
@@ -249,35 +278,43 @@ apply_rough_alignment_example = {
     "pool_size": 20
 }
 
-
-
 # EM Montage QC data
-PRESTITCHED_STACK_INPUT_JSON = render_json_template(example_env, 'em_montage_qc_pre_tilespecs.json',
-                                                    test_data_root=TEST_DATA_ROOT)
+PRESTITCHED_STACK_INPUT_JSON = render_json_template(
+        example_env,
+        'em_montage_qc_pre_tilespecs.json',
+        test_data_root=TEST_DATA_ROOT)
 
-POSTSTITCHED_STACK_INPUT_JSON = render_json_template(example_env, 'em_montage_qc_post_tilespecs.json',
-                                                    test_data_root=TEST_DATA_ROOT)
+POSTSTITCHED_STACK_INPUT_JSON = render_json_template(
+        example_env,
+        'em_montage_qc_post_tilespecs.json',
+        test_data_root=TEST_DATA_ROOT)
 
-MONTAGE_QC_POINT_MATCH_JSON = render_json_template(example_env, 'em_montage_qc_point_matches.json')
+MONTAGE_QC_POINT_MATCH_JSON = render_json_template(
+        example_env,
+        'em_montage_qc_point_matches.json')
 
 montage_qc_project = "em_montage_qc_test"
 
 # Point match optimization
-PT_MATCH_STACK_TILESPECS = render_json_template(example_env, 'pt_match_optimization_tilespecs.json',
-                                                test_data_root=TEST_DATA_ROOT)
+PT_MATCH_STACK_TILESPECS = render_json_template(
+        example_env,
+        'pt_match_optimization_tilespecs.json',
+        test_data_root=TEST_DATA_ROOT)
 
 
 # Solver testing
-solver_montage_parameters = render_json_template(example_env, 'solver_montage_test.json',
-                                                 render_project = "solver_montage_project",
-                                                 render_host=render_host,
-                                                 render_owner=render_test_owner,
-                                                 render_port=render_port,
-                                                 mongo_port=os.environ.get('MONGO_PORT', 27017),
-                                                 render_mongo_host=os.environ.get('RENDER_MONGO_HOST', 'localhost'),
-                                                 render_output_owner=render_test_owner,
-                                                 render_client_scripts=client_script_location,
-                                                 solver_output_dir=tempfile.mkdtemp())
+solver_montage_parameters = render_json_template(
+        example_env,
+        'solver_montage_test.json',
+        render_project="solver_montage_project",
+        render_host=render_host,
+        render_owner=render_test_owner,
+        render_port=render_port,
+        mongo_port=os.environ.get('MONGO_PORT', 27017),
+        render_mongo_host=os.environ.get('RENDER_MONGO_HOST', 'localhost'),
+        render_output_owner=render_test_owner,
+        render_client_scripts=client_script_location,
+        solver_output_dir=tempfile.mkdtemp())
 
 FUSION_TILESPEC_JSON = render_json_template(
     example_env, 'fusion_test_tilespecs_ref.json',

--- a/integration_tests/test_downsample_mask.py
+++ b/integration_tests/test_downsample_mask.py
@@ -87,10 +87,7 @@ def matches_are_filtered(render, collection):
                 collection, group1, group2, render=render)
     ids = []
     for m in matches:
-        if np.count_nonzero(
-                np.isclose(
-                    np.array(m['matches']['w']),
-                    0.0)) != 0:
+        if np.any(np.isclose(np.array(m['matches']['w']), 0.0)):
             ids.append([m['pGroupId'], m['qGroupId']])
     return ids
 

--- a/integration_tests/test_downsample_mask.py
+++ b/integration_tests/test_downsample_mask.py
@@ -1,0 +1,219 @@
+import os
+import renderapi
+import json
+from test_data import (
+        TEST_DATA_ROOT,
+        render_params)
+
+from rendermodules.rough_align.downsample_mask_handler import (
+        DownsampleMaskHandler, points_in_mask)
+from rendermodules.module.render_module import \
+        RenderModuleException
+import pytest
+import numpy as np
+
+DS_MASK_TEST_PATH = os.path.join(
+        TEST_DATA_ROOT,
+        "em_modules_test_data",
+        "downsample_masking")
+DS_MASK_PATH = os.path.join(
+        DS_MASK_TEST_PATH,
+        "masks")
+DS_BAD_MASK_PATH = os.path.join(
+        DS_MASK_TEST_PATH,
+        "bad_masks")
+DS_TSPEC_PATH = os.path.join(
+        DS_MASK_TEST_PATH,
+        "ds_tilespecs.json")
+DS_COLLECTION_PATH = os.path.join(
+        DS_MASK_TEST_PATH,
+        "ds_matches.json")
+
+
+@pytest.fixture(scope='module')
+def render():
+    render_params['project'] = 'downsample_mask_test'
+    render = renderapi.connect(**render_params)
+    return render
+
+
+@pytest.fixture(scope='module')
+def downsampled_stack(render):
+    with open(DS_TSPEC_PATH, 'r') as f:
+        tspecs = [
+            renderapi.tilespec.TileSpec(json=i)
+            for i in json.load(f)]
+
+    stack = "downsampled_stack_for_masks"
+    renderapi.stack.create_stack(stack, render=render)
+    renderapi.client.import_tilespecs(stack,
+                                      tspecs,
+                                      render=render)
+    renderapi.stack.set_stack_state(stack,
+                                    'COMPLETE',
+                                    render=render)
+    yield stack
+
+
+@pytest.fixture(scope='module')
+def downsampled_collection(render):
+    collection = "downsampled_collection_for_masks"
+    with open(DS_COLLECTION_PATH, 'r') as f:
+        renderapi.pointmatch.import_matches(
+                collection,
+                json.load(f),
+                render=render)
+    yield collection
+
+
+def zs_have_masks(render, stack):
+    tspecs = renderapi.tilespec.get_tile_specs_from_stack(
+            stack,
+            render=render)
+    zs = [{'z': t.z, 'group': t.layout.sectionId}
+          for t in tspecs if t.ip[0].maskUrl is not None]
+    return zs
+
+
+def matches_are_filtered(render, collection):
+    groups = renderapi.pointmatch.get_match_groupIds(
+            collection,
+            render=render)
+    matches = []
+    for i in range(len(groups)):
+        for j in range(i):
+            matches += renderapi.pointmatch.get_matches_from_group_to_group(
+                    collection, groups[i], groups[j], render=render)
+    ids = []
+    for m in matches:
+        if np.count_nonzero(
+                np.isclose(
+                    np.array(m['matches']['w']),
+                    0.0)) != 0:
+            ids.append([m['pGroupId'], m['qGroupId']])
+    return ids
+
+
+def test_points_in_mask():
+    mask = np.zeros((1000, 1000)).astype('uint8')
+    # render masks areas where mask = 0
+    mask[0:500, :] = 255
+
+    # all should be weight=1 (included)
+    w1pts = np.random.rand(2, 100)
+    w1pts[0, :] *= 1000
+    w1pts[1, :] *= 500
+    w1 = points_in_mask(mask, w1pts.tolist())
+    assert np.all(np.isclose(w1, 1.0))
+
+    # all should be weight=0 (excluded)
+    w0pts = np.random.rand(2, 100)
+    w0pts[0, :] *= 1000
+    w0pts[1, :] *= 500
+    w0pts[1, :] += 500
+    w0 = points_in_mask(mask, w0pts.tolist())
+    assert np.all(np.isclose(w0, 0.0))
+
+
+def test_masks(render, downsampled_stack, downsampled_collection):
+    # check that the starting point has no masks and nothing filtered
+    assert len(zs_have_masks(render, downsampled_stack)) == 0
+    assert len(matches_are_filtered(render, downsampled_collection)) == 0
+
+    render_params['project'] = 'downsample_mask_test'
+    input_args = {
+            "render": render_params,
+            "mask_dir": DS_MASK_PATH,
+            "stack": downsampled_stack,
+            "collection": downsampled_collection,
+            "zMask": [10395, 10398],
+            "zReset": None,
+            "log_level": "WARNING"
+            }
+
+    dsmod = DownsampleMaskHandler(input_data=input_args, args=[])
+    dsmod.run()
+
+    # check that the stack now has masks where we asked
+    # and that the collection is filtered
+    zhm = zs_have_masks(render, downsampled_stack)
+    assert [iz['z'] for iz in zhm] == input_args['zMask']
+    for ids in matches_are_filtered(render, downsampled_collection):
+        assert np.any([iz['group'] in ids for iz in zhm])
+
+    # reset those masks
+    input_args['zReset'] = list(input_args['zMask'])
+    input_args['zMask'] = None
+    dsmod = DownsampleMaskHandler(input_data=input_args, args=[])
+    dsmod.run()
+    assert len(zs_have_masks(render, downsampled_stack)) == 0
+    assert len(matches_are_filtered(render, downsampled_collection)) == 0
+    # run it again (it was already reset)
+    with pytest.raises(RenderModuleException):
+        dsmod.run()
+    assert len(zs_have_masks(render, downsampled_stack)) == 0
+    assert len(matches_are_filtered(render, downsampled_collection)) == 0
+
+    # ask for a z value outside of the stack z range
+    input_args['zMask'] = [10392, 10395]
+    input_args['zReset'] = None
+    dsmod = DownsampleMaskHandler(input_data=input_args, args=[])
+    dsmod.run()
+    zhm = zs_have_masks(render, downsampled_stack)
+    assert [iz['z'] for iz in zhm] == [10395]
+    for ids in matches_are_filtered(render, downsampled_collection):
+        assert np.any([iz['group'] in ids for iz in zhm])
+    # run it again (there's already a mask)
+    with pytest.raises(RenderModuleException):
+        dsmod.run()
+    zhm = zs_have_masks(render, downsampled_stack)
+    assert [iz['z'] for iz in zhm] == [10395]
+    for ids in matches_are_filtered(render, downsampled_collection):
+        assert np.any([iz['group'] in ids for iz in zhm])
+
+    # reset those masks
+    input_args['zMask'] = None
+    input_args['zReset'] = [10395]
+    dsmod = DownsampleMaskHandler(input_data=input_args, args=[])
+    dsmod.run()
+    assert len(zs_have_masks(render, downsampled_stack)) == 0
+    assert len(matches_are_filtered(render, downsampled_collection)) == 0
+
+    # 2 mask filenames match
+    input_args['zMask'] = [10395, 10398]
+    input_args['zReset'] = None
+    input_args['mask_dir'] = DS_BAD_MASK_PATH
+    dsmod = DownsampleMaskHandler(input_data=input_args, args=[])
+    with pytest.raises(RenderModuleException):
+        dsmod.run()
+    assert len(zs_have_masks(render, downsampled_stack)) == 0
+    assert len(matches_are_filtered(render, downsampled_collection)) == 0
+
+    # make a z that has multiple tile specs
+    tspecs = [
+            renderapi.tilespec.get_tile_specs_from_z(
+                downsampled_stack,
+                z,
+                render=render)[0]
+            for z in [10395, 10396]]
+    for t in tspecs:
+        t.tileId = '%d_%s_junk' % (t.z, t.layout.sectionId)
+        t.z = 10392
+    renderapi.client.import_tilespecs(downsampled_stack, tspecs, render=render)
+    input_args['zMask'] = [10392]
+    input_args['mask_dir'] = DS_BAD_MASK_PATH
+    input_args['zReset'] = None
+    dsmod = DownsampleMaskHandler(input_data=input_args, args=[])
+    with pytest.raises(RenderModuleException):
+        dsmod.run()
+    renderapi.stack.delete_section(downsampled_stack, 10392, render=render)
+    assert len(zs_have_masks(render, downsampled_stack)) == 0
+    assert len(matches_are_filtered(render, downsampled_collection)) == 0
+
+    # remove a mask that isn't there
+    input_args['zMask'] = None
+    input_args['zReset'] = [10392]
+    input_args['mask_dir'] = DS_MASK_PATH
+    dsmod = DownsampleMaskHandler(input_data=input_args, args=[])
+    dsmod.run()
+    assert len(zs_have_masks(render, downsampled_stack)) == 0

--- a/integration_tests/test_downsample_mask.py
+++ b/integration_tests/test_downsample_mask.py
@@ -12,6 +12,7 @@ from rendermodules.module.render_module import \
 import pytest
 import numpy as np
 from shapely.geometry import Polygon, Point
+import itertools
 
 DS_MASK_TEST_PATH = os.path.join(
         TEST_DATA_ROOT,
@@ -81,10 +82,9 @@ def matches_are_filtered(render, collection):
             collection,
             render=render)
     matches = []
-    for i in range(len(groups)):
-        for j in range(i):
-            matches += renderapi.pointmatch.get_matches_from_group_to_group(
-                    collection, groups[i], groups[j], render=render)
+    for group1, group2 in itertools.combinations(groups, 2):
+        matches += renderapi.pointmatch.get_matches_from_group_to_group(
+                collection, group1, group2, render=render)
     ids = []
     for m in matches:
         if np.count_nonzero(

--- a/integration_tests/test_lens_correction.py
+++ b/integration_tests/test_lens_correction.py
@@ -112,6 +112,7 @@ def test_points(example_tform_dict):
     return test_points
 
 
+#@pytest.fixture(scope='module')
 def compute_lc_norm_and_max(test_example_tform, test_new_tform):
     tform_norm = (
             np.linalg.norm(test_new_tform - test_example_tform) /

--- a/integration_tests/test_lens_correction.py
+++ b/integration_tests/test_lens_correction.py
@@ -112,7 +112,6 @@ def test_points(example_tform_dict):
     return test_points
 
 
-#@pytest.fixture(scope='module')
 def compute_lc_norm_and_max(test_example_tform, test_new_tform):
     tform_norm = (
             np.linalg.norm(test_new_tform - test_example_tform) /

--- a/integration_tests/test_rough_align.py
+++ b/integration_tests/test_rough_align.py
@@ -823,6 +823,7 @@ def test_apply_rough_alignment_with_masks(render, montage_stack, test_do_rough_a
              ex['output_stack'], render=render))
          assert(ntiles == ntiles_montage - 3)
          renderapi.stack.delete_stack(ex['lowres_stack'], render=render)
+         renderapi.stack.delete_stack(ex['output_stack'], render=render)
 
      # modify the input stack
      renderapi.stack.clone_stack(orig_lowres, ex['lowres_stack'], render=render)
@@ -839,6 +840,7 @@ def test_apply_rough_alignment_with_masks(render, montage_stack, test_do_rough_a
      assert lrs[0].ip['0']['maskUrl'] is None
      assert lrs[1].ip['0']['maskUrl'] is not None
      assert lrs[2].ip['0']['maskUrl'] is None
+     renderapi.stack.delete_stack(ex['output_stack'], render=render)
      #renderapi.stack.delete_stack(ex['lowres_stack'], render=render)
 
      # read the masks from the lowres stack (just modified above)
@@ -848,7 +850,7 @@ def test_apply_rough_alignment_with_masks(render, montage_stack, test_do_rough_a
          ex['output_stack'], render=render))
      assert(ntiles == ntiles_montage - 3)
      renderapi.stack.delete_stack(ex['lowres_stack'], render=render)
-
+  
      # make multiple matches for one tileId
      mpath = urllib.parse.unquote(
                  urllib.parse.urlparse(

--- a/integration_tests/test_rough_align.py
+++ b/integration_tests/test_rough_align.py
@@ -197,7 +197,7 @@ def montage_scape_stack(render, montage_stack, downsample_sections_dir):
     assert(set(zvalues) == set(zs))
 
     yield output_stack
-    #renderapi.stack.delete_stack(output_stack, render=render)
+    renderapi.stack.delete_stack(output_stack, render=render)
 
 @pytest.fixture(scope='module')
 def montage_scape_stack_with_scale(render, montage_stack, downsample_sections_dir):
@@ -476,7 +476,7 @@ def test_do_rough_alignment(render, montage_scape_stack, rough_point_match_colle
     assert(set(zvalues) == set(zs))
 
     yield output_lowres_stack
-    #renderapi.stack.delete_stack(output_lowres_stack, render=render)
+    renderapi.stack.delete_stack(output_lowres_stack, render=render)
 
 
 @pytest.fixture(scope="module")
@@ -582,7 +582,7 @@ def test_do_rough_alignment_with_scale(render, montage_scape_stack_with_scale, r
     assert(set(zvalues) == set(zs))
 
     yield output_lowres_stack
-    #renderapi.stack.delete_stack(output_lowres_stack, render=render)
+    renderapi.stack.delete_stack(output_lowres_stack, render=render)
 
 @pytest.fixture(scope='module')
 def test_do_rough_alignment_python(
@@ -841,7 +841,6 @@ def test_apply_rough_alignment_with_masks(render, montage_stack, test_do_rough_a
      assert lrs[1].ip['0']['maskUrl'] is not None
      assert lrs[2].ip['0']['maskUrl'] is None
      renderapi.stack.delete_stack(ex['output_stack'], render=render)
-     #renderapi.stack.delete_stack(ex['lowres_stack'], render=render)
 
      # read the masks from the lowres stack (just modified above)
      ex['read_masks_from_lowres_stack'] = True

--- a/rendermodules/module/schemas/stack_schemas.py
+++ b/rendermodules/module/schemas/stack_schemas.py
@@ -37,7 +37,10 @@ class ZValueParameters(  # argschema.schemas.DefaultSchema,
     minZ = argschema.fields.Int(required=False)
     maxZ = argschema.fields.Int(required=False)
     z = argschema.fields.Int(required=False)
-    zValues = argschema.fields.List(argschema.fields.Int, required=False)
+    zValues = argschema.fields.List(
+            argschema.fields.Int,
+            cli_as_single_argument=True,
+            required=False)
 
     @post_load
     def generate_zValues(self, data):
@@ -87,8 +90,10 @@ class RenderStackVersion(argschema.schemas.DefaultSchema):
     mipmapPathBuilder = argschema.fields.Nested(RenderMipMapPathBuilder,
                                                 required=False)
     cycle = argschema.fields.Nested(RenderCycle, required=False)
-    stackResolutionValues = argschema.fields.List(argschema.fields.Int,
-                                                  required=False)
+    stackResolutionValues = argschema.fields.List(
+            argschema.fields.Int,
+            cli_as_single_argument=True,
+            required=False)
 
 
 class OutputStackParameters(RenderParameters, ZValueParameters,

--- a/rendermodules/rough_align/apply_rough_alignment_to_montages.py
+++ b/rendermodules/rough_align/apply_rough_alignment_to_montages.py
@@ -160,8 +160,10 @@ def filter_highres_with_masks(resolved_highres, tspec_lowres, mask_map):
         tc = t.bbox_transformed(
                     reference_tforms=resolved_highres.transforms)
         tpoly = Polygon(tc).buffer(0)
-        for p in mask_polygons:
-            if not p.intersects(tpoly):
+        pint = [not p.intersects(tpoly) for p in mask_polygons]
+        if np.all(pint):
+        #for p in mask_polygons:
+        #    if not p.intersects(tpoly):
                 new_highres.append(t)
 
     return new_highres

--- a/rendermodules/rough_align/apply_rough_alignment_to_montages.py
+++ b/rendermodules/rough_align/apply_rough_alignment_to_montages.py
@@ -82,22 +82,18 @@ def get_mask_paths(
                 results[t.tileId] = t.ip[0].maskUrl
 
     elif mask_input_dir is not None:
-        tids = [t.tileId for t in tilespecs]
-        maskfiles = []
-        for ext in exts:
-            e = mask_input_dir + '/*.' + ext
-            maskfiles += glob.glob(e)
-        maskbasenames = np.array([os.path.basename(os.path.splitext(p)[0])
-                                  for p in maskfiles])
-        for t in tids:
-            ind = np.argwhere(maskbasenames == t).flatten()
-            if ind.size > 1:
-                raise RenderModuleException("more than one mask in "
-                                            "directory %s matches tileId %s" %
-                                            (mask_input_dir, t))
-            if ind.size == 0:
-                continue
-            results[t] = pathlib.Path(maskfiles[ind[0]]).as_uri()
+        for t in tilespecs:
+            for ext in exts:
+                e = os.path.join(
+                        mask_input_dir,
+                        t.tileId + os.extsep + ext)
+                if os.path.isfile(e):
+                    if t.tileId in results:
+                        raise RenderModuleException(
+                                "more than one mask in "
+                                "directory %s matches tileId %s" %
+                                (mask_input_dir, t))
+                    results[t.tileId] = pathlib.Path(e).as_uri()
 
     return results
 

--- a/rendermodules/rough_align/downsample_mask_handler.py
+++ b/rendermodules/rough_align/downsample_mask_handler.py
@@ -1,0 +1,192 @@
+import renderapi
+from renderapi.errors import RenderError
+from rendermodules.rough_align.schemas import (
+        DownsampleMaskHandlerSchema)
+from rendermodules.module.render_module import (
+        RenderModule, RenderModuleException)
+import glob
+import os
+import pathlib
+import numpy as np
+import cv2
+from six.moves import urllib
+from shapely.geometry import Polygon, Point
+
+
+example = {
+        "render": {
+           "host": "em-131fs",
+           "port": 8987,
+           "owner": "TEM",
+           "project": "17797_1R",
+           "client_scripts": "/allen/aibs/pipeline/image_processing"
+                             "/volume_assembly/render-jars/production/scripts"
+        },
+        "mask_dir": "/allen/programs/celltypes/workgroups/em-connectomics"
+                    "/danielk/split_masks/section_masks",
+        "stack": "em_2d_montage_solved_py_0_01_mapped",
+        "collection": "chunk_rough_align_point_matches",
+        "zMask": [10395, 10398],
+        "zReset": None
+        }
+
+
+def points_in_mask(mask, pts):
+    # openCV >= 4.0:
+    # contours, _ = cv2.findContours(
+    #         mask, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
+    # openCV < 4.0:
+    _, contours, _ = cv2.findContours(
+            mask, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
+    maskpoly = Polygon(contours[0].squeeze())
+    mask_list = [1.0 if maskpoly.contains(Point(pt)) else 0.0
+                 for pt in np.array(pts).transpose()]
+    return mask_list
+
+
+def filter_match(m, tspecs):
+    tgroups = np.array([t.layout.sectionId for t in tspecs])
+    for pq in ['p', 'q']:
+        tspec_ind = np.argwhere(tgroups == m[pq + 'GroupId']).flatten()
+        if tspec_ind.size > 0:
+            mask_path = urllib.parse.unquote(urllib.parse.urlparse(
+                tspecs[tspec_ind[0]].ip['0'].maskUrl).path)
+            mask = cv2.imread(mask_path, 0)
+            m['matches']['w'] = points_in_mask(mask, m['matches'][pq])
+    return m
+
+
+def reset_match(m):
+    m['matches']['w'] = [1.0] * len(m['matches']['w'])
+    return m
+
+
+class DownsampleMaskHandler(RenderModule):
+    default_schema = DownsampleMaskHandlerSchema
+
+    def get_tilespec(self, z):
+        try:
+            tspecs = renderapi.tilespec.get_tile_specs_from_z(
+                    self.args['stack'],
+                    z,
+                    render=self.render)
+        except RenderError:
+            return None
+
+        if len(tspecs) != 1:
+            raise RenderModuleException(
+                "Expected 1 tilespec for z=%d, found %d" % (z, len(tspecs)))
+
+        return tspecs[0]
+
+    def add_mask_to_tilespec(self, z):
+        tspec = self.get_tilespec(z)
+        if not tspec:
+            return tspec
+
+        if tspec.ip[0].maskUrl is not None:
+            raise RenderModuleException(
+                    "Tilespec already has a mask for z = %d" % (z))
+
+        fnames = glob.glob(os.path.join(
+            self.args['mask_dir'], '%d_*.png' % z))
+
+        if len(fnames) != 1:
+            raise RenderModuleException(
+                    "Expected 1 mask file for z = %d, found %d in %s" %
+                    (z, len(fnames), self.args['mask_dir']))
+
+        tspec.ip['0'].maskUrl = pathlib.Path(fnames[0]).as_uri()
+
+        return tspec
+
+    def remove_mask_from_tilespec(self, z):
+        tspec = self.get_tilespec(z)
+        if not tspec:
+            return tspec
+
+        if tspec.ip[0].maskUrl is None:
+            raise RenderModuleException(
+                "Tilespec does not have a mask for z = %d" % (z))
+
+        tspec.ip[0].maskUrl = None
+
+        return tspec
+
+    def run(self):
+        self.render = renderapi.connect(**self.args['render'])
+
+        tspecs = []
+        # add a mask for any zMask not in zReset
+        if self.args['zMask']:
+            for z in np.setdiff1d(self.args['zMask'], self.args['zReset']):
+                tspec = self.add_mask_to_tilespec(z)
+                if tspec:
+                    tspecs.append(tspec)
+
+        # remove a mask for any zReset
+        for z in np.setdiff1d(self.args['zReset'], None):
+            tspec = self.remove_mask_from_tilespec(z)
+            if tspec:
+                tspecs.append(tspec)
+
+        if len(tspecs) > 0:
+            renderapi.client.import_tilespecs(
+                    self.args['stack'],
+                    tspecs,
+                    render=self.render)
+            if self.args['close_stack']:
+                renderapi.stack.set_stack_state(
+                        self.args['stack'],
+                        state='COMPLETE',
+                        render=self.render)
+
+        # filter point matches based on zMask
+        tspecs = []
+        if self.args['zMask']:
+            for z in np.setdiff1d(self.args['zMask'], self.args['zReset']):
+                tspec = self.get_tilespec(z)
+                if tspec:
+                    tspecs.append(tspec)
+            groups = [t.layout.sectionId for t in tspecs]
+            matches = []
+            for g in groups:
+                matches += renderapi.pointmatch.get_matches_outside_group(
+                        self.args['collection'],
+                        g,
+                        render=self.render)
+            for m in matches:
+                m = filter_match(m, tspecs)
+
+            renderapi.pointmatch.import_matches(
+                    self.args['collection'],
+                    matches,
+                    render=self.render)
+
+        # remove any masking for each zReset
+        tspecs = []
+        for z in np.setdiff1d(self.args['zReset'], None):
+            tspec = self.get_tilespec(z)
+            if tspec:
+                tspecs.append(tspec)
+                if tspec:
+                    tspecs.append(tspec)
+            groups = [t.layout.sectionId for t in tspecs]
+            matches = []
+            for g in groups:
+                matches += renderapi.pointmatch.get_matches_outside_group(
+                        self.args['collection'],
+                        g,
+                        render=self.render)
+                for m in matches:
+                    m = reset_match(m)
+
+            renderapi.pointmatch.import_matches(
+                    self.args['collection'],
+                    matches,
+                    render=self.render)
+
+
+if __name__ == "__main__":
+    dsmod = DownsampleMaskHandler(input_data=example, args=[])
+    dsmod.run()

--- a/rendermodules/rough_align/downsample_mask_handler.py
+++ b/rendermodules/rough_align/downsample_mask_handler.py
@@ -32,6 +32,7 @@ example = {
 
 
 def points_in_mask(mask, pts):
+    # findContours is changing return values.
     # openCV >= 4.0:
     # contours, _ = cv2.findContours(
     #         mask, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)

--- a/rendermodules/rough_align/downsample_mask_handler.py
+++ b/rendermodules/rough_align/downsample_mask_handler.py
@@ -114,8 +114,6 @@ class DownsampleMaskHandler(RenderModule):
         return tspec
 
     def run(self):
-        self.render = renderapi.connect(**self.args['render'])
-
         tspecs = []
         # add a mask for any zMask not in zReset
         if self.args['zMask']:

--- a/rendermodules/rough_align/downsample_mask_handler.py
+++ b/rendermodules/rough_align/downsample_mask_handler.py
@@ -32,7 +32,6 @@ example = {
 
 
 def points_in_mask(mask, pts):
-    # findContours is changing return values.
     # openCV >= 4.0:
     # contours, _ = cv2.findContours(
     #         mask, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)

--- a/rendermodules/rough_align/downsample_mask_handler.py
+++ b/rendermodules/rough_align/downsample_mask_handler.py
@@ -167,8 +167,6 @@ class DownsampleMaskHandler(RenderModule):
             tspec = self.get_tilespec(z)
             if tspec:
                 tspecs.append(tspec)
-                if tspec:
-                    tspecs.append(tspec)
             groups = [t.layout.sectionId for t in tspecs]
             matches = []
             for g in groups:

--- a/rendermodules/rough_align/downsample_mask_handler.py
+++ b/rendermodules/rough_align/downsample_mask_handler.py
@@ -118,7 +118,7 @@ class DownsampleMaskHandler(RenderModule):
 
         return tspecs[0]
 
-    def add_mask_to_tilespec(self, z):
+    def add_mask_to_tilespec(self, z, exts):
         tspec = self.get_tilespec(z)
         if not tspec:
             return tspec
@@ -127,8 +127,12 @@ class DownsampleMaskHandler(RenderModule):
             raise RenderModuleException(
                     "Tilespec already has a mask for z = %d" % (z))
 
-        fnames = glob.glob(os.path.join(
-            self.args['mask_dir'], '%d_*.png' % z))
+        fnames = []
+        for ext in exts:
+            fnames += glob.glob(
+                        os.path.join(
+                            self.args['mask_dir'],
+                            '%d_*' % z + os.extsep + ext))
 
         if len(fnames) != 1:
             raise RenderModuleException(
@@ -157,7 +161,7 @@ class DownsampleMaskHandler(RenderModule):
         # add a mask for any zMask not in zReset
         if self.args['zMask']:
             for z in np.setdiff1d(self.args['zMask'], self.args['zReset']):
-                tspec = self.add_mask_to_tilespec(z)
+                tspec = self.add_mask_to_tilespec(z, self.args['mask_exts'])
                 if tspec:
                     tspecs.append(tspec)
 

--- a/rendermodules/rough_align/schemas.py
+++ b/rendermodules/rough_align/schemas.py
@@ -557,3 +557,9 @@ class DownsampleMaskHandlerSchema(RenderParameters):
         default=None,
         cli_as_single_argument=True,
         description=("z values for which the masks will be reset"))
+    mask_exts = List(
+        Str,
+        required=False,
+        default=['png', 'tif'],
+        description="what kind of mask files to recognize")
+

--- a/rendermodules/rough_align/schemas.py
+++ b/rendermodules/rough_align/schemas.py
@@ -2,8 +2,8 @@ from argschema import InputDir
 import marshmallow as mm
 from argschema.fields import Bool, Float, Int, Nested, Str, InputFile, List
 from argschema.schemas import DefaultSchema
-from ..module.schemas import RenderParameters
-from marshmallow import post_load, ValidationError
+from ..module.schemas import RenderParameters, OutputStackParameters
+from marshmallow import post_load, ValidationError, pre_load
 import argschema
 
 
@@ -519,3 +519,41 @@ class ApplyRoughAlignmentOutputParameters(DefaultSchema):
             description="list of z values that were applied to")
     output_stack = argschema.fields.Str(
             description="stack where applied transforms were set")
+
+
+class DownsampleMaskHandlerSchema(RenderParameters):
+    stack = argschema.fields.Str(
+        required=True,
+        description="stack that is read and modified with masks")
+    close_stack = argschema.fields.Bool(
+        require=True,
+        default=True,
+        missing=True,
+        description="set COMPLETE or not")
+    mask_dir = argschema.fields.InputDir(
+        required=True,
+        missing=None,
+        default=None,
+        description=("directory containing masks, named <z>_*.png where"
+                     "<z> is a z value in input_stack and may be specified"
+                     "in z_apply"))
+    collection = argschema.fields.Str(
+        required=True,
+        missing=None,
+        default=None,
+        description=("name of collection to be filtered by mask, or reset"
+                     "can be None for no operation"))
+    zMask = argschema.fields.List(
+        argschema.fields.Int,
+        required=True,
+        missing=None,
+        default=None,
+        cli_as_single_argument=True,
+        description=("z values for which the masks will be set"))
+    zReset = argschema.fields.List(
+        argschema.fields.Int,
+        required=True,
+        missing=None,
+        default=None,
+        cli_as_single_argument=True,
+        description=("z values for which the masks will be reset"))


### PR DESCRIPTION
* One of the steps in improving rough alignment (Jan/Feb 2019) was to mask off some split sections and also ignore the point matches in the masked areas.
* Previously, we had already added mask handling in apply_rough. This PR is just giving some functionality for adding masks and filtering point matches. 
* The intent is for it to run out-of-workflow (open to debate...). I found that I had to experiment with what masks to include and which ones were not necessary. So, I ended up having something that put them in and took them out, both for the stack and the collection. This is just a clean version of that manual/scripty thing I was doing.
* Some time ago, we had the experience that RANSAC automagically chose one half of a split section. That turned out not to hold true always, so I think the point match filter part of this is necessary for clean rough alignment.
* Also, pytest is up to 4.0 and that broke an unrelated test in test_lens_correction, so that explains the last commit and why master build is currently broken.