### PR TITLE
adding validation to apply mipmaps

### DIFF
--- a/integration_tests/test_rough_align.py
+++ b/integration_tests/test_rough_align.py
@@ -85,7 +85,6 @@ def montage_stack(render, resolvedtiles_from_json):
     renderapi.stack.delete_stack(test_montage_stack, render=render)
 
 
-
 @pytest.fixture(scope='module')
 def one_tile_montage(render, tspecs):
     one_tile_montage_stack = 'one_tile_montage_stack'
@@ -104,7 +103,6 @@ def one_tile_montage(render, tspecs):
 
     yield one_tile_montage_stack
     render.run(renderapi.stack.delete_stack, one_tile_montage_stack)
-
 
 
 @pytest.fixture(scope='module')
@@ -168,6 +166,7 @@ def rough_point_matches_from_json():
     point_matches = [d for d in ROUGH_POINT_MATCH_COLLECTION]
     return point_matches
 
+
 @pytest.fixture(scope='module')
 def rough_mapped_pt_matches_from_json():
     pt_matches = [d for d in ROUGH_MAPPED_PT_MATCH_COLLECTION]
@@ -197,6 +196,7 @@ def montage_scape_stack(render, montage_stack, downsample_sections_dir):
 
     yield output_stack
     #renderapi.stack.delete_stack(output_stack, render=render)
+
 
 @pytest.fixture(scope='module')
 def montage_scape_stack_with_scale(render, montage_stack, downsample_sections_dir):
@@ -332,7 +332,8 @@ def test_do_mapped_rough_alignment(render, montage_z_mapped_stack, rough_mapped_
         output_lowres_stack = '{}_DS_Rough'.format(montage_z_mapped_stack)
 
     output_directory = str(tmpdir_factory.mktemp('output_json'))
-    solver_ex = dict(solver_example, **{
+    solver_ex = copy.deepcopy(solver_example)
+    solver_ex = dict(solver_ex, **{
         'output_json': os.path.join(output_directory,'output.json'),
         'first_section': 251,
         'last_section': 253,
@@ -357,14 +358,14 @@ def test_do_mapped_rough_alignment(render, montage_z_mapped_stack, rough_mapped_
     renderapi.stack.delete_stack(output_lowres_stack, render=render)
 
 
-
 @pytest.fixture(scope='module')
 def test_do_rough_alignment(render, montage_scape_stack, rough_point_match_collection, tmpdir_factory, output_lowres_stack=None):
     if output_lowres_stack == None:
         output_lowres_stack = '{}_DS_Rough'.format(montage_scape_stack)
 
     output_directory = str(tmpdir_factory.mktemp('output_json'))
-    solver_ex = dict(solver_example, **{
+    solver_ex = copy.deepcopy(solver_example)
+    solver_ex = dict(solver_ex, **{
         'output_json': os.path.join(output_directory,'output.json'),
         'source_collection': dict(solver_example['source_collection'], **{
             'stack': montage_scape_stack}),
@@ -402,7 +403,8 @@ def test_do_rough_alignment_with_scale(render, montage_scape_stack_with_scale, r
         output_lowres_stack = '{}_DS_Rough_scale'.format(montage_scape_stack_with_scale)
 
     output_directory = str(tmpdir_factory.mktemp('output_json'))
-    solver_ex = dict(solver_example, **{
+    solver_ex = copy.deepcopy(solver_example)
+    solver_ex = dict(solver_ex, **{
         'output_json': os.path.join(output_directory,'output.json'),
         'source_collection': dict(solver_example['source_collection'], **{
             'stack': montage_scape_stack_with_scale}),
@@ -423,6 +425,7 @@ def test_do_rough_alignment_with_scale(render, montage_scape_stack_with_scale, r
 
     yield output_lowres_stack
     #renderapi.stack.delete_stack(output_lowres_stack, render=render)
+
 
 @pytest.fixture(scope='module')
 def test_do_rough_alignment_python(
@@ -559,6 +562,7 @@ def test_apply_rough_alignment_transform(render, montage_stack, test_do_rough_al
          assert all([isinstance(
              ts.tforms[0], renderapi.transform.ReferenceTransform)
                      for ts in out_resolvedtiles.tilespecs])
+
 
 
 def modular_test_for_masks(render, ex):
@@ -829,6 +833,7 @@ def test_make_montage_stack_module_without_downsamples(
     assert os.path.isfile(tsfn)
     assert os.path.basename(tsfn) == '1020.0.png'
 
+
 def test_apply_rough_alignment_transform_with_scale(render, montage_stack, test_do_rough_alignment_with_scale, tmpdir_factory, prealigned_stack=None, output_stack=None):
     ex = dict(ex1, **{
         'render': dict(ex1['render'], **render_params),
@@ -869,9 +874,6 @@ def test_apply_rough_alignment_transform_with_scale(render, montage_stack, test_
                     for ts in out_resolvedtiles.tilespecs])
 
 
-
-
-
 def test_make_montage_scape_stack_fail(render, montage_stack, downsample_sections_dir):
     output_stack = '{}_DS'.format(montage_stack)
     params = {
@@ -899,7 +901,6 @@ def test_make_montage_scape_stack_fail(render, montage_stack, downsample_section
         mod.run()
 
 
-
 def test_setting_new_z_montage_scape(render, montage_stack, downsample_sections_dir):
     output_stack = '{}_DS'.format(montage_stack)
     params = {
@@ -920,7 +921,6 @@ def test_setting_new_z_montage_scape(render, montage_stack, downsample_sections_
 
     zvalues = renderapi.stack.get_z_values_for_stack(output_stack, render=render)
     assert(set(zvalues) == set([1020, 1021, 1022]))
-
 
 
 def test_solver_default_options(render, montage_scape_stack, rough_point_match_collection, tmpdir_factory):

--- a/rendermodules/dataimport/apply_mipmaps_to_render.py
+++ b/rendermodules/dataimport/apply_mipmaps_to_render.py
@@ -113,7 +113,7 @@ class AddMipMapsToStack(StackTransitionModule):
         for z in zvalues:
             input_rs = renderapi.resolvedtiles.get_resolved_tiles_from_z(input_stack, z, render=self.render)
             output_rs = renderapi.resolvedtiles.get_resolved_tiles_from_z(output_stack, z, render=self.render)
-            if len(input_rs.tilespecs) != len(output_rs.tilespecs):
+            if len(input_rs.tilespecs) != len(output_rs.tilespecs): # pragma: no cover
                 missing_ts_zs.append(z)
         
         return missing_ts_zs

--- a/rendermodules/dataimport/apply_mipmaps_to_render.py
+++ b/rendermodules/dataimport/apply_mipmaps_to_render.py
@@ -102,7 +102,22 @@ class AddMipMapsToStack(StackTransitionModule):
 
         self.output_tilespecs_to_stack(tilespecs, output_stack,
                                        sharedTransforms=identified_tforms)
-        self.output({"output_stack": output_stack})
+
+        missing_ts_zs = self.validate_apply_mipmaps(self.args['input_stack'], output_stack, zvalues)
+
+        self.output({"output_stack": output_stack, "missing_tilespecs_zs": missing_ts_zs})
+
+    def validate_apply_mipmaps(self, input_stack, output_stack, zvalues):
+        missing_ts_zs = []
+        
+        for z in zvalues:
+            input_rs = renderapi.resolvedtiles.get_resolved_tiles_from_z(input_stack, z, render=self.render)
+            output_rs = renderapi.resolvedtiles.get_resolved_tiles_from_z(output_stack, z, render=self.render)
+            if len(input_rs.tilespecs) != len(output_rs.tilespecs):
+                missing_ts_zs.append(z)
+        
+        return missing_ts_zs
+
 
 
 if __name__ == "__main__":

--- a/rendermodules/dataimport/schemas.py
+++ b/rendermodules/dataimport/schemas.py
@@ -1,6 +1,6 @@
 import warnings
 import marshmallow as mm
-from argschema.fields import InputDir, InputFile, Str, Int, Boolean, Float
+from argschema.fields import InputDir, InputFile, Str, Int, Boolean, Float, List
 from ..module.schemas import (StackTransitionParameters, InputStackParameters,
                               OutputStackParameters)
 from marshmallow import ValidationError, post_load
@@ -62,6 +62,12 @@ class GenerateMipMapsParameters(InputStackParameters):
 
 class AddMipMapsToStackOutput(DefaultSchema):
     output_stack = Str(required=True)
+    missing_tilespecs_zs = List(Int,
+                                required=False,
+                                default=[],
+                                missing=[],
+                                cli_as_single_argument=True,
+                                description="Z values for which apply mipmaps failed")
 
 
 class AddMipMapsToStackParameters(StackTransitionParameters):


### PR DESCRIPTION
Apply mipmaps was not ingesting some tiles in some sections during Phase 2, which was detected at the montage manual qc stage. 

Adding the check in apply mipmaps, that produces the list of Zs for which apply mipmaps failed.. 
This can be consumed in the workflow strategy to fail the job for each montage based on this output. 