### PR TITLE
utilities: add matplotlib_utils

### DIFF
--- a/integration_tests/test_lens_correction.py
+++ b/integration_tests/test_lens_correction.py
@@ -11,7 +11,7 @@ from rendermodules.mesh_lens_correction.do_mesh_lens_correction import \
         make_mask
 from test_data import render_params, TILESPECS_NO_LC_JSON, TILESPECS_LC_JSON
 from test_data import calc_lens_parameters
-import matplotlib.pyplot as plt
+import imageio
 from six.moves import urllib
 import os
 
@@ -256,6 +256,6 @@ def test_apply_lens_correction_mask(
             mpath = urllib.parse.unquote(
                     urllib.parse.urlparse(mm.maskUrl).path)
             assert(os.path.isfile(mpath))
-            mask = plt.imread(mpath)
+            mask = imageio.imread(mpath)
             assert (mask.shape[0] == height / (2**int(lvl)))
             assert (mask.shape[1] == width / (2**int(lvl)))

--- a/rendermodules/utilities/matplotlib_utils.py
+++ b/rendermodules/utilities/matplotlib_utils.py
@@ -1,0 +1,10 @@
+# imports needed for rough_align_qc
+import os
+import matplotlib as mpl
+if os.environ.get('DISPLAY', '') == '':
+    mpl.use('Agg')
+
+import matplotlib.pyplot as plt  # noqa: E402,F401
+import mpld3  # noqa: E402,F401
+from matplotlib.backends.backend_pdf import PdfPages  # noqa: E402,F401
+from descartes.patch import PolygonPatch  # noqa: E402,F401

--- a/rendermodules/utilities/pillow_utils.py
+++ b/rendermodules/utilities/pillow_utils.py
@@ -1,14 +1,3 @@
 from PIL import Image
 
 Image.MAX_IMAGE_PIXELS = None
-
-# imports needed for rough_align_qc
-import os
-import matplotlib as mpl
-if os.environ.get('DISPLAY', '') == '':
-    mpl.use('Agg')
-
-import matplotlib.pyplot as plt
-import mpld3
-from matplotlib.backends.backend_pdf import PdfPages
-from descartes.patch import PolygonPatch


### PR DESCRIPTION
Unfortunately, there are a fair amount of whitespace-only changes included in this.  This makes it so tests pass using `renderapi.utilities.matplotli_utils` by removing unnecessary `matplotlib.pyplot` imports (which weren't actually being used in the first place?)