### PR TITLE
Python37 compat

### DIFF
--- a/rendermodules/dataimport/generate_EM_tilespecs_from_metafile.py
+++ b/rendermodules/dataimport/generate_EM_tilespecs_from_metafile.py
@@ -5,7 +5,7 @@ create tilespecs from TEMCA metadata file
 
 import json
 import os
-import pathlib
+import pathlib2 as pathlib
 import numpy
 import renderapi
 from rendermodules.module.render_module import (

--- a/rendermodules/dataimport/make_montage_scapes_stack.py
+++ b/rendermodules/dataimport/make_montage_scapes_stack.py
@@ -3,7 +3,7 @@ from functools import partial
 import glob
 import os
 import numpy as np
-import pathlib
+import pathlib2 as pathlib
 import renderapi
 from rendermodules.utilities.pillow_utils import Image
 from rendermodules.materialize.render_downsample_sections import (
@@ -192,7 +192,7 @@ class MakeMontageScapeSectionStack(StackOutputModule):
 
     def run(self):
         self.logger.debug('Montage scape stack generation module')
-        
+
         # get the list of z indices
         zvalues = self.render.run(
             renderapi.stack.get_z_values_for_stack,
@@ -222,7 +222,7 @@ class MakeMontageScapeSectionStack(StackOutputModule):
             outzvalues = renderapi.stack.get_z_values_for_stack(
                             self.args['output_stack'],
                             render=self.render)
-            
+
             if self.overwrite_zlayer:
                 # stack has to be in loading state
                 renderapi.stack.set_stack_state(self.args['output_stack'],
@@ -230,10 +230,10 @@ class MakeMontageScapeSectionStack(StackOutputModule):
                                                 render=self.render)
                 for oldz, newz in zip(zvalues, newzvalues):
                     # delete the section from output stack
-                    renderapi.stack.delete_section(self.args['output_stack'], 
-                                                   newz, 
+                    renderapi.stack.delete_section(self.args['output_stack'],
+                                                   newz,
                                                    render=self.render)
-        
+
 
         # generate the tag string to add to output tilespec json file name
         tagstr = "%s_%s" % (min(zvalues), max(zvalues))

--- a/rendermodules/lens_correction/apply_lens_correction.py
+++ b/rendermodules/lens_correction/apply_lens_correction.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import renderapi
 import os
-import pathlib
+import pathlib2 as pathlib
 from rendermodules.module.render_module import StackTransitionModule
 from rendermodules.lens_correction.schemas import \
         ApplyLensCorrectionOutput, ApplyLensCorrectionParameters
@@ -117,7 +117,7 @@ class ApplyLensCorrection(StackTransitionModule):
         for z in self.zValues:
             job_success = self.validate_tilespecs(self.input_stack, outputStack, z)
             if not job_success:
-               missing_ts_zs.append(z) 
+               missing_ts_zs.append(z)
 
         # output dict
         output = {}

--- a/rendermodules/pointmatch_filter/filter_point_matches.py
+++ b/rendermodules/pointmatch_filter/filter_point_matches.py
@@ -206,14 +206,14 @@ class FilterMatches(RenderModule):
             results = pool.map(proc_job, fargs)
 
         with open(self.args['filter_output_file'], 'w') as f:
-            json.dump(
+            renderapi.utils.renderdump(
                     [x for x in results if x is not None],
                     f,
                     indent=2)
 
         with open(self.args['output_json'], 'w') as f:
             outj = {'filter_output_file': self.args['filter_output_file']}
-            json.dump(outj, f, indent=2)
+            renderapi.utils.renderdump(outj, f, indent=2)
 
 
 if __name__ == '__main__':

--- a/rendermodules/rough_align/apply_rough_alignment_to_montages.py
+++ b/rendermodules/rough_align/apply_rough_alignment_to_montages.py
@@ -13,7 +13,7 @@ from rendermodules.rough_align.downsample_mask_handler \
 from functools import partial
 import logging
 import requests
-import pathlib
+import pathlib2 as pathlib
 import cv2
 from six.moves import urllib
 from shapely.geometry import Polygon
@@ -187,7 +187,7 @@ def apply_rough_alignment(render,
                           remap_section_ids=False):
     z = Z[0] # z value from the montage stack - to be mapped to the newz values in lowres stack
     newz = Z[1] # z value in the lowres stack for this montage
-    
+
     session=requests.session()
     try:
         # get lowres stack tile specs
@@ -265,7 +265,7 @@ def apply_rough_alignment(render,
             t.z = newz
             if remap_section_ids:
                 t.layout.sectionId = "%s.0"%str(int(newz))
-        
+
         if filter_montage_output_with_masks:
             tf.M[0:2, 0:2] /= scale
             resolved_highrests1.tilespecs = highres_ts1

--- a/rendermodules/rough_align/downsample_mask_handler.py
+++ b/rendermodules/rough_align/downsample_mask_handler.py
@@ -6,7 +6,7 @@ from rendermodules.module.render_module import (
         RenderModule, RenderModuleException)
 import glob
 import os
-import pathlib
+import pathlib2 as pathlib
 import numpy as np
 import cv2
 from six.moves import urllib

--- a/rendermodules/stack/redirect_mipmaps.py
+++ b/rendermodules/stack/redirect_mipmaps.py
@@ -4,7 +4,7 @@ change storage directory of imageUrl in a given mipMapLevel
 """
 import copy
 import os
-import pathlib
+import pathlib2 as pathlib
 
 import renderapi
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ argschema>=1.15.17
 numpy
 pillow
 tifffile
-pathlib
+pathlib2
 scipy
 rtree
 networkx


### PR DESCRIPTION
fixes pathlib backport for python 2.7 and passes tests on python 3.7.  Should be merged in after #200, since that resolve a python 3 issue as well.