### PR TITLE
Skip deprecated

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -21,3 +21,6 @@ exclude_lines =
     logger.critical
     # ignore name is main
     if __name__ == .__main__.
+
+omit =
+    rendermodules/deprecated/*

--- a/integration_tests/test_data.py
+++ b/integration_tests/test_data.py
@@ -1,8 +1,8 @@
-
 import os
 from jinja2 import Environment, FileSystemLoader
 import json
 import tempfile
+import marshmallow
 
 pool_size = os.environ.get('RENDERMODULES_POOL_SIZE', 5)
 
@@ -346,3 +346,13 @@ FUSION_TILESPEC_JSON = render_json_template(
 FUSION_TRANSFORM_JSON = render_json_template(
     example_env, 'fusion_test_tform_ref.json', test_data_root=TEST_DATA_ROOT)
 
+# whether to test legacy (deprecated) modules
+b = marshmallow.fields.Boolean()
+test_legacy = b.deserialize(os.environ.get(
+    "RENDERMODULES_TEST_LEGACY", False))
+test_legacy_lens_correction = b.deserialize(os.environ.get(
+    "RENDERMODULES_TEST_LEGACY_LC", test_legacy))
+test_legacy_montage = b.deserialize(os.environ.get(
+    "RENDERMODULES_TEST_LEGACY_MONTAGE", test_legacy))
+test_legacy_rough = b.deserialize(os.environ.get(
+    "RENDERMODULES_TEST_LEGACY_ROUGH", test_legacy))

--- a/integration_tests/test_lens_correction.py
+++ b/integration_tests/test_lens_correction.py
@@ -10,8 +10,9 @@ from rendermodules.deprecated.lens_correction.lens_correction import (
     LensCorrectionModule)
 from rendermodules.mesh_lens_correction.do_mesh_lens_correction import (
         make_mask)
-from test_data import render_params, TILESPECS_NO_LC_JSON, TILESPECS_LC_JSON
-from test_data import calc_lens_parameters
+from test_data import (
+    render_params, TILESPECS_NO_LC_JSON, TILESPECS_LC_JSON,
+    calc_lens_parameters, test_legacy_lens_correction)
 import imageio
 from six.moves import urllib
 import os
@@ -124,6 +125,9 @@ def compute_lc_norm_and_max(test_example_tform, test_new_tform):
     assert tform_norm < 1
 
 
+@pytest.mark.skipif(not test_legacy_lens_correction, reason=(
+    "legacy code not being tested -- to test, "
+    "set environment variable RENDERMODULES_TEST_LEGACY_LC"))
 def test_calc_lens_correction(example_tform_dict, test_points, tmpdir):
     outfile = str(tmpdir.join('test_LC_out.json'))
     print(outfile)

--- a/integration_tests/test_matlab_solver.py
+++ b/integration_tests/test_matlab_solver.py
@@ -13,13 +13,20 @@ from test_data import (RAW_STACK_INPUT_JSON,
                       montage_z,
                       test_em_montage_parameters as solver_example,
                       test_pointmatch_parameters as pointmatch_example,
-                      test_pointmatch_parameters_qsub as pointmatch_example_qsub)
+                      test_pointmatch_parameters_qsub as pointmatch_example_qsub,
+                      test_legacy_montage)
 
 from rendermodules.deprecated.montage.run_montage_job_for_section import  SolveMontageSectionModule
 from rendermodules.pointmatch.create_tilepairs import TilePairClientModule
 from rendermodules.pointmatch.generate_point_matches_spark import PointMatchClientModuleSpark
 from rendermodules.pointmatch.generate_point_matches_qsub import PointMatchClientModuleQsub
 from rendermodules.module.render_module import RenderModuleException
+
+# skip these tests if not explicitly asked for
+pytestmark = pytest.mark.skipif(not test_legacy_montage, reason=(
+    "legacy code not being tested -- to test, "
+    "set environment variable RENDERMODULES_TEST_LEGACY_MONTAGE"))
+
 
 @pytest.fixture(scope='module')
 def render():

--- a/integration_tests/test_rough_align_matlab.py
+++ b/integration_tests/test_rough_align_matlab.py
@@ -19,7 +19,8 @@ from test_data import (
         test_rough_parameters as solver_example,
         apply_rough_alignment_example as ex1,
         rough_solver_example as solver_input,
-        pool_size)
+        pool_size,
+        test_legacy_rough)
 from rendermodules.module.render_module import RenderModuleException
 from rendermodules.materialize.render_downsample_sections import RenderSectionAtScale, create_tilespecs_without_mipmaps
 from rendermodules.dataimport.make_montage_scapes_stack import MakeMontageScapeSectionStack, create_montage_scape_tile_specs
@@ -29,6 +30,12 @@ from rendermodules.rough_align.apply_rough_alignment_to_montages import (ApplyRo
                                                                          apply_rough_alignment)
 import shutil
 import numpy as np
+
+# skip these tests if not explicitly asked for
+pytestmark = pytest.mark.skipif(not test_legacy_rough, reason=(
+    "legacy code not being tested -- to test, "
+    "set environment variable RENDERMODULES_TEST_LEGACY_ROUGH"))
+
 
 @pytest.fixture(scope='module')
 def render():


### PR DESCRIPTION
adds functionality to skip testing of legacy code (MATLAB solver, TrakEM2 lens correction) by default while allowing those tests to be run selectively with environment variables.  Also modifies the coveragerc to omit everything under deprecated.

This follows #203, and resolves #193 and #192 