### PR TITLE
Multi-channel support

### DIFF
--- a/integration_tests/test_data.py
+++ b/integration_tests/test_data.py
@@ -108,6 +108,14 @@ MULTIPLICATIVE_INPUT_JSON = render_json_template(
 #     'allen/aibs/pipeline/image_processing/volume_assembly/lc_test_data/')
 
 
+multiplicative_multichan_correction_example_dir = os.path.join(
+    TEST_DATA_ROOT, 'multichannel_test_data')
+
+MULTIPLICATIVE_MULTICHAN_INPUT_JSON = render_json_template(
+        example_env,
+        'multichan_intensity_correction_template.json',
+        test_data_root=TEST_DATA_ROOT)
+
 calc_lens_parameters = render_json_template(
         example_env,
         'calc_lens_correction_parameters.json',

--- a/integration_tests/test_files/multichan_intensity_correction_template.json
+++ b/integration_tests/test_files/multichan_intensity_correction_template.json
@@ -1,0 +1,491 @@
+[
+    {
+        "tileId": "104000000000000",
+        "layout": {
+            "sectionId": "4000",
+            "temca": "Leica",
+            "camera": "zyla",
+            "imageRow": 0,
+            "imageCol": 0,
+            "stageX": -10629.9,
+            "stageY": 28068.0,
+            "rotation": 0.0
+        },
+        "z": 400.0,
+        "minX": 0.0,
+        "minY": 0.0,
+        "maxX": 2048.0,
+        "maxY": 2048.0,
+        "width": 2048.0,
+        "height": 2048.0,
+        "minIntensity": 0.0,
+        "maxIntensity": 50000.0,
+        "mipmapLevels": {
+            "0": {
+                "imageUrl": "file:{{test_data_root}}/multichannel_test_data/M33Quarter/raw/DAPI_1/DAPI_1_S0000_F0000_Z00.tif"
+            }
+        },
+        "channels": [
+            {
+                "name": "PSD95",
+                "minIntensity": 0.0,
+                "maxIntensity": 50000.0,
+                "mipmapLevels": {
+                    "0": {
+                        "imageUrl": "file:{{test_data_root}}/multichannel_test_data/M33Quarter/raw/PSD95/PSD95_S0000_F0000_Z00.tif"
+                    }
+                }
+            },
+            {
+                "name": "DAPI_1",
+                "minIntensity": 0.0,
+                "maxIntensity": 50000.0,
+                "mipmapLevels": {
+                    "0": {
+                        "imageUrl": "file:{{test_data_root}}/multichannel_test_data/M33Quarter/raw/DAPI_1/DAPI_1_S0000_F0000_Z00.tif"
+                    }
+                }
+            }
+        ],
+        "transforms": {
+            "type": "list",
+            "specList": [
+                {
+                    "type": "leaf",
+                    "className": "mpicbg.trakem2.transform.AffineModel2D",
+                    "dataString": "1.0000000000 0.0000000000 0.0000000000 1.0000000000 0.9692270414 0.0000000000"
+                }
+            ]
+        },
+        "meshCellSize": 64.0
+    },
+    {
+        "tileId": "104000000001000",
+        "layout": {
+            "sectionId": "4000",
+            "temca": "Leica",
+            "camera": "zyla",
+            "imageRow": 0,
+            "imageCol": 0,
+            "stageX": -10460.9,
+            "stageY": 28068.0,
+            "rotation": 0.0
+        },
+        "z": 400.0,
+        "minX": 1638.0,
+        "minY": 0.0,
+        "maxX": 3686.0,
+        "maxY": 2048.0,
+        "width": 2048.0,
+        "height": 2048.0,
+        "minIntensity": 0.0,
+        "maxIntensity": 50000.0,
+        "mipmapLevels": {
+            "0": {
+                "imageUrl": "file:{{test_data_root}}/multichannel_test_data/M33Quarter/raw/DAPI_1/DAPI_1_S0000_F0001_Z00.tif"
+            }
+        },
+        "channels": [
+            {
+                "name": "PSD95",
+                "minIntensity": 0.0,
+                "maxIntensity": 50000.0,
+                "mipmapLevels": {
+                    "0": {
+                        "imageUrl": "file:{{test_data_root}}/multichannel_test_data/M33Quarter/raw/PSD95/PSD95_S0000_F0001_Z00.tif"
+                    }
+                }
+            },
+            {
+                "name": "DAPI_1",
+                "minIntensity": 0.0,
+                "maxIntensity": 50000.0,
+                "mipmapLevels": {
+                    "0": {
+                        "imageUrl": "file:{{test_data_root}}/multichannel_test_data/M33Quarter/raw/DAPI_1/DAPI_1_S0000_F0001_Z00.tif"
+                    }
+                }
+            }
+        ],
+        "transforms": {
+            "type": "list",
+            "specList": [
+                {
+                    "type": "leaf",
+                    "className": "mpicbg.trakem2.transform.AffineModel2D",
+                    "dataString": "1.0000000000 0.0000000000 0.0000000000 1.0000000000 1638.9629270657 0.0000000000"
+                }
+            ]
+        },
+        "meshCellSize": 64.0
+    },
+    {
+        "tileId": "104000000002000",
+        "layout": {
+            "sectionId": "4000",
+            "temca": "Leica",
+            "camera": "zyla",
+            "imageRow": 0,
+            "imageCol": 0,
+            "stageX": -10291.8,
+            "stageY": 28068.0,
+            "rotation": 0.0
+        },
+        "z": 400.0,
+        "minX": 3277.0,
+        "minY": 0.0,
+        "maxX": 5325.0,
+        "maxY": 2048.0,
+        "width": 2048.0,
+        "height": 2048.0,
+        "minIntensity": 0.0,
+        "maxIntensity": 50000.0,
+        "mipmapLevels": {
+            "0": {
+                "imageUrl": "file:{{test_data_root}}/multichannel_test_data/M33Quarter/raw/DAPI_1/DAPI_1_S0000_F0002_Z00.tif"
+            }
+        },
+        "channels": [
+            {
+                "name": "PSD95",
+                "minIntensity": 0.0,
+                "maxIntensity": 50000.0,
+                "mipmapLevels": {
+                    "0": {
+                        "imageUrl": "file:{{test_data_root}}/multichannel_test_data/M33Quarter/raw/PSD95/PSD95_S0000_F0002_Z00.tif"
+                    }
+                }
+            },
+            {
+                "name": "DAPI_1",
+                "minIntensity": 0.0,
+                "maxIntensity": 50000.0,
+                "mipmapLevels": {
+                    "0": {
+                        "imageUrl": "file:{{test_data_root}}/multichannel_test_data/M33Quarter/raw/DAPI_1/DAPI_1_S0000_F0002_Z00.tif"
+                    }
+                }
+            }
+        ],
+        "transforms": {
+            "type": "list",
+            "specList": [
+                {
+                    "type": "leaf",
+                    "className": "mpicbg.trakem2.transform.AffineModel2D",
+                    "dataString": "1.0000000000 0.0000000000 0.0000000000 1.0000000000 3277.9258541313 0.0000000000"
+                }
+            ]
+        },
+        "meshCellSize": 64.0
+    },
+    {
+        "tileId": "104000000003000",
+        "layout": {
+            "sectionId": "4000",
+            "temca": "Leica",
+            "camera": "zyla",
+            "imageRow": 0,
+            "imageCol": 0,
+            "stageX": -10123.0,
+            "stageY": 28068.0,
+            "rotation": 0.0
+        },
+        "z": 400.0,
+        "minX": 4913.0,
+        "minY": 0.0,
+        "maxX": 6961.0,
+        "maxY": 2048.0,
+        "width": 2048.0,
+        "height": 2048.0,
+        "minIntensity": 0.0,
+        "maxIntensity": 50000.0,
+        "mipmapLevels": {
+            "0": {
+                "imageUrl": "file:{{test_data_root}}/multichannel_test_data/M33Quarter/raw/DAPI_1/DAPI_1_S0000_F0003_Z00.tif"
+            }
+        },
+        "channels": [
+            {
+                "name": "PSD95",
+                "minIntensity": 0.0,
+                "maxIntensity": 50000.0,
+                "mipmapLevels": {
+                    "0": {
+                        "imageUrl": "file:{{test_data_root}}/multichannel_test_data/M33Quarter/raw/PSD95/PSD95_S0000_F0003_Z00.tif"
+                    }
+                }
+            },
+            {
+                "name": "DAPI_1",
+                "minIntensity": 0.0,
+                "maxIntensity": 50000.0,
+                "mipmapLevels": {
+                    "0": {
+                        "imageUrl": "file:{{test_data_root}}/multichannel_test_data/M33Quarter/raw/DAPI_1/DAPI_1_S0000_F0003_Z00.tif"
+                    }
+                }
+            }
+        ],
+        "transforms": {
+            "type": "list",
+            "specList": [
+                {
+                    "type": "leaf",
+                    "className": "mpicbg.trakem2.transform.AffineModel2D",
+                    "dataString": "1.0000000000 0.0000000000 0.0000000000 1.0000000000 4913.9811000727 0.0000000000"
+                }
+            ]
+        },
+        "meshCellSize": 64.0
+    },
+    {
+        "tileId": "104000000004000",
+        "layout": {
+            "sectionId": "4000",
+            "temca": "Leica",
+            "camera": "zyla",
+            "imageRow": 0,
+            "imageCol": 0,
+            "stageX": -10122.7,
+            "stageY": 28237.3,
+            "rotation": 0.0
+        },
+        "z": 400.0,
+        "minX": 4916.0,
+        "minY": 1640.0,
+        "maxX": 6964.0,
+        "maxY": 3688.0,
+        "width": 2048.0,
+        "height": 2048.0,
+        "minIntensity": 0.0,
+        "maxIntensity": 50000.0,
+        "mipmapLevels": {
+            "0": {
+                "imageUrl": "file:{{test_data_root}}/multichannel_test_data/M33Quarter/raw/DAPI_1/DAPI_1_S0000_F0004_Z00.tif"
+            }
+        },
+        "channels": [
+            {
+                "name": "PSD95",
+                "minIntensity": 0.0,
+                "maxIntensity": 50000.0,
+                "mipmapLevels": {
+                    "0": {
+                        "imageUrl": "file:{{test_data_root}}/multichannel_test_data/M33Quarter/raw/PSD95/PSD95_S0000_F0004_Z00.tif"
+                    }
+                }
+            },
+            {
+                "name": "DAPI_1",
+                "minIntensity": 0.0,
+                "maxIntensity": 50000.0,
+                "mipmapLevels": {
+                    "0": {
+                        "imageUrl": "file:{{test_data_root}}/multichannel_test_data/M33Quarter/raw/DAPI_1/DAPI_1_S0000_F0004_Z00.tif"
+                    },
+                    "1": {
+                        "imageUrl": "file:/data/atp-testdata/input/M33Quarter//./processed/helloworldD/downsamp_images/data/Ribbon0004/session01/DAPI_1_S0000_F0004_Z00_mip01.jpg"
+                    },
+                    "2": {
+                        "imageUrl": "file:/data/atp-testdata/input/M33Quarter//./processed/helloworldD/downsamp_images/data/Ribbon0004/session01/DAPI_1_S0000_F0004_Z00_mip02.jpg"
+                    },
+                    "3": {
+                        "imageUrl": "file:/data/atp-testdata/input/M33Quarter//./processed/helloworldD/downsamp_images/data/Ribbon0004/session01/DAPI_1_S0000_F0004_Z00_mip03.jpg"
+                    }
+                }
+            }
+        ],
+        "transforms": {
+            "type": "list",
+            "specList": [
+                {
+                    "type": "leaf",
+                    "className": "mpicbg.trakem2.transform.AffineModel2D",
+                    "dataString": "1.0000000000 0.0000000000 0.0000000000 1.0000000000 4916.8887811970 1640.9013811485"
+                }
+            ]
+        },
+        "meshCellSize": 64.0
+    },
+    {
+        "tileId": "104000000005000",
+        "layout": {
+            "sectionId": "4000",
+            "temca": "Leica",
+            "camera": "zyla",
+            "imageRow": 0,
+            "imageCol": 0,
+            "stageX": -10291.9,
+            "stageY": 28237.1,
+            "rotation": 0.0
+        },
+        "z": 400.0,
+        "minX": 3276.0,
+        "minY": 1638.0,
+        "maxX": 5324.0,
+        "maxY": 3686.0,
+        "width": 2048.0,
+        "height": 2048.0,
+        "minIntensity": 0.0,
+        "maxIntensity": 50000.0,
+        "mipmapLevels": {
+            "0": {
+                "imageUrl": "file:{{test_data_root}}/multichannel_test_data/M33Quarter/raw/DAPI_1/DAPI_1_S0000_F0005_Z00.tif"
+            }
+        },
+        "channels": [
+            {
+                "name": "PSD95",
+                "minIntensity": 0.0,
+                "maxIntensity": 50000.0,
+                "mipmapLevels": {
+                    "0": {
+                        "imageUrl": "file:{{test_data_root}}/multichannel_test_data/M33Quarter/raw/PSD95/PSD95_S0000_F0005_Z00.tif"
+                    }
+                }
+            },
+            {
+                "name": "DAPI_1",
+                "minIntensity": 0.0,
+                "maxIntensity": 50000.0,
+                "mipmapLevels": {
+                    "0": {
+                        "imageUrl": "file:{{test_data_root}}/multichannel_test_data/M33Quarter/raw/DAPI_1/DAPI_1_S0000_F0005_Z00.tif"
+                    }
+                }
+            }
+        ],
+        "transforms": {
+            "type": "list",
+            "specList": [
+                {
+                    "type": "leaf",
+                    "className": "mpicbg.trakem2.transform.AffineModel2D",
+                    "dataString": "1.0000000000 0.0000000000 0.0000000000 1.0000000000 3276.9566270899 1638.9629270657"
+                }
+            ]
+        },
+        "meshCellSize": 64.0
+    },
+    {
+        "tileId": "104000000006000",
+        "layout": {
+            "sectionId": "4000",
+            "temca": "Leica",
+            "camera": "zyla",
+            "imageRow": 0,
+            "imageCol": 0,
+            "stageX": -10461.0,
+            "stageY": 28237.1,
+            "rotation": 0.0
+        },
+        "z": 400.0,
+        "minX": 1637.0,
+        "minY": 1638.0,
+        "maxX": 3685.0,
+        "maxY": 3686.0,
+        "width": 2048.0,
+        "height": 2048.0,
+        "minIntensity": 0.0,
+        "maxIntensity": 50000.0,
+        "mipmapLevels": {
+            "0": {
+                "imageUrl": "file:{{test_data_root}}/multichannel_test_data/M33Quarter/raw/DAPI_1/DAPI_1_S0000_F0006_Z00.tif"
+            }
+        },
+        "channels": [
+            {
+                "name": "PSD95",
+                "minIntensity": 0.0,
+                "maxIntensity": 50000.0,
+                "mipmapLevels": {
+                    "0": {
+                        "imageUrl": "file:{{test_data_root}}/multichannel_test_data/M33Quarter/raw/PSD95/PSD95_S0000_F0006_Z00.tif"
+                    }
+                }
+            },
+            {
+                "name": "DAPI_1",
+                "minIntensity": 0.0,
+                "maxIntensity": 50000.0,
+                "mipmapLevels": {
+                    "0": {
+                        "imageUrl": "file:{{test_data_root}}/multichannel_test_data/M33Quarter/raw/DAPI_1/DAPI_1_S0000_F0006_Z00.tif"
+                    }
+                }
+            }
+        ],
+        "transforms": {
+            "type": "list",
+            "specList": [
+                {
+                    "type": "leaf",
+                    "className": "mpicbg.trakem2.transform.AffineModel2D",
+                    "dataString": "1.0000000000 0.0000000000 0.0000000000 1.0000000000 1637.9937000242 1638.9629270657"
+                }
+            ]
+        },
+        "meshCellSize": 64.0
+    },
+    {
+        "tileId": "104000000007000",
+        "layout": {
+            "sectionId": "4000",
+            "temca": "Leica",
+            "camera": "zyla",
+            "imageRow": 0,
+            "imageCol": 0,
+            "stageX": -10630.0,
+            "stageY": 28237.1,
+            "rotation": 0.0
+        },
+        "z": 400.0,
+        "minX": 0.0,
+        "minY": 1638.0,
+        "maxX": 2048.0,
+        "maxY": 3686.0,
+        "width": 2048.0,
+        "height": 2048.0,
+        "minIntensity": 0.0,
+        "maxIntensity": 50000.0,
+        "mipmapLevels": {
+            "0": {
+                "imageUrl": "file:{{test_data_root}}/multichannel_test_data/M33Quarter/raw/DAPI_1/DAPI_1_S0000_F0007_Z00.tif"
+            }
+        },
+        "channels": [
+            {
+                "name": "PSD95",
+                "minIntensity": 0.0,
+                "maxIntensity": 50000.0,
+                "mipmapLevels": {
+                    "0": {
+                        "imageUrl": "file:{{test_data_root}}/multichannel_test_data/M33Quarter/raw/PSD95/PSD95_S0000_F0007_Z00.tif"
+                    }
+                }
+            },
+            {
+                "name": "DAPI_1",
+                "minIntensity": 0.0,
+                "maxIntensity": 50000.0,
+                "mipmapLevels": {
+                    "0": {
+                        "imageUrl": "file:{{test_data_root}}/multichannel_test_data/M33Quarter/raw/DAPI_1/DAPI_1_S0000_F0007_Z00.tif"
+                    }
+                }
+            }
+        ],
+        "transforms": {
+            "type": "list",
+            "specList": [
+                {
+                    "type": "leaf",
+                    "className": "mpicbg.trakem2.transform.AffineModel2D",
+                    "dataString": "1.0000000000 0.0000000000 0.0000000000 1.0000000000 0.0000000000 1638.9629270657"
+                }
+            ]
+        },
+        "meshCellSize": 64.0
+    }
+]

--- a/integration_tests/test_multichan_multiplicative_correction.py
+++ b/integration_tests/test_multichan_multiplicative_correction.py
@@ -9,7 +9,7 @@ import random
 from test_data import (MULTIPLICATIVE_MULTICHAN_INPUT_JSON, multiplicative_multichan_correction_example_dir,
                        render_params)
 from rendermodules.intensity_correction.calculate_multiplicative_correction import MakeMedian
-from rendermodules.intensity_correction.apply_multiplicative_correction import MultIntensityCorr, getImage, process_tile_multichan
+from rendermodules.intensity_correction.apply_multiplicative_correction import MultIntensityCorr, getImage, process_tile
 
 
 @pytest.fixture(scope='module')
@@ -123,10 +123,10 @@ def test_single_tile(test_apply_correction,render,tmpdir):
     for channel in ["DAPI_1","PSD95"]:
         _, _, corr_dict[channel] = getImage(corr_tilespecs[0], channel=channel)
 
-	#process_tile_multichan(C, corr_dict, dirout, stackname, clip, scale_factor, clip_min, clip_max, input_ts)
-    process_tile_multichan(C,
-                 corr_dict,
+	#process_tile(C, corr_dict, dirout, stackname, clip, scale_factor, clip_min, clip_max, input_ts, corr_dict=None)
+    process_tile(C,
                  test_apply_correction.args['output_directory'],
                  test_apply_correction.args['output_stack'],
 		 True, 1.0,0,65535,
-                 inp_tilespecs[0])
+                 inp_tilespecs[0],
+                 corr_dict=corr_dict)

--- a/integration_tests/test_multichan_multiplicative_correction.py
+++ b/integration_tests/test_multichan_multiplicative_correction.py
@@ -9,7 +9,7 @@ import random
 from test_data import (MULTIPLICATIVE_MULTICHAN_INPUT_JSON, multiplicative_multichan_correction_example_dir,
                        render_params)
 from rendermodules.intensity_correction.calculate_multiplicative_correction import MakeMedian
-from rendermodules.intensity_correction.apply_multiplicative_correction import MultIntensityCorr, getImage, process_tile
+from rendermodules.intensity_correction.apply_multiplicative_correction import MultIntensityCorr, getImage, process_tile_multichan
 
 
 @pytest.fixture(scope='module')
@@ -123,8 +123,8 @@ def test_single_tile(test_apply_correction,render,tmpdir):
     for channel in ["DAPI_1","PSD95"]:
         _, _, corr_dict[channel] = getImage(corr_tilespecs[0], channel=channel)
 
-	#process_tile(C, corr_dict, dirout, stackname, clip,scale_factor,clip_min,clip_max,input_ts)
-    process_tile(C,
+	#process_tile_multichan(C, corr_dict, dirout, stackname, clip, scale_factor, clip_min, clip_max, input_ts)
+    process_tile_multichan(C,
                  corr_dict,
                  test_apply_correction.args['output_directory'],
                  test_apply_correction.args['output_stack'],

--- a/integration_tests/test_multichan_multiplicative_correction.py
+++ b/integration_tests/test_multichan_multiplicative_correction.py
@@ -1,0 +1,132 @@
+
+import os
+import pytest
+import logging
+import renderapi
+import tifffile
+import numpy as np
+import random
+from test_data import (MULTIPLICATIVE_MULTICHAN_INPUT_JSON, multiplicative_multichan_correction_example_dir,
+                       render_params)
+from rendermodules.intensity_correction.calculate_multiplicative_correction import MakeMedian
+from rendermodules.intensity_correction.apply_multiplicative_correction import MultIntensityCorr, getImage, process_tile
+
+
+@pytest.fixture(scope='module')
+def render():
+    render_params['project']='multi_mc_correct_test'
+    render = renderapi.connect(**render_params)
+    return render
+
+@pytest.fixture(scope='module')
+def test_tilespecs():
+     tilespecs = [renderapi.tilespec.TileSpec(json=d) for d in MULTIPLICATIVE_MULTICHAN_INPUT_JSON]
+     return tilespecs
+
+@pytest.fixture(scope='module')
+def raw_stack(render,test_tilespecs):
+    stack = 'input_raw'
+    renderapi.stack.create_stack(stack, render=render)
+    renderapi.client.import_tilespecs(
+        stack, test_tilespecs, render=render)
+    renderapi.stack.set_stack_state(stack, 'COMPLETE', render=render)
+    yield stack
+    renderapi.stack.delete_stack(stack, render=render)
+
+
+@pytest.fixture(scope='module')
+def mini_raw_stack(render,test_tilespecs):
+    stack = 'mini_input_raw'
+    renderapi.stack.create_stack(stack, render=render)
+    tilespecs = random.sample(test_tilespecs, 5)
+
+    renderapi.client.import_tilespecs(stack, tilespecs, render=render)
+    renderapi.stack.set_stack_state(stack, 'COMPLETE', render=render)
+    yield stack
+    renderapi.stack.delete_stack(stack, render=render)
+
+
+@pytest.fixture(scope='module')
+def test_median_stack(raw_stack, render, tmpdir_factory):
+    median_stack = 'median_stack'
+    output_directory = str(tmpdir_factory.mktemp('median'))
+    #output_directory = os.path.join(multiplicative_multichan_correction_example_dir,'median')
+    params = {
+        "render": render_params,
+        "input_stack": raw_stack,
+        "file_prefix": "Median",
+        "output_stack": median_stack,
+        "output_directory": output_directory,
+        "minZ": 400,
+        "maxZ": 400,
+        "pool_size": 3,
+        "log_level": "DEBUG"
+    }
+    mod = MakeMedian(input_data=params, args=[])
+    mod.run()
+
+    median_tilespecs = renderapi.tilespec.get_tile_specs_from_stack(
+        median_stack, render=render)
+    for channel in ["DAPI_1","PSD95"]:
+        N, M, median_image = getImage(median_tilespecs[0], channel=channel)
+        expected_median_file = os.path.join(
+            multiplicative_multichan_correction_example_dir, 'median', 'Median_median_stack_%s_400-400.tif' % channel)
+        expect_median = tifffile.imread(expected_median_file)
+
+    assert(np.max(np.abs(median_image - expect_median)) < 3)
+
+    yield median_stack
+
+@pytest.fixture(scope='module')
+def test_apply_correction(test_median_stack, mini_raw_stack, render, tmpdir_factory):
+    output_directory = str(tmpdir_factory.mktemp('intensity_corrected'))
+    #output_directory = os.path.join(multiplicative_multichan_correction_example_dir, 'intensity_corrected')
+    output_stack = "Flatfield_corrected_test"
+    params = {
+        "render": render_params,
+        "input_stack": mini_raw_stack,
+        "correction_stack": test_median_stack,
+        "output_stack": output_stack,
+        "output_directory": output_directory,
+        "z_index": 400,
+        "pool_size": 1,
+        "overwrite_zlayer": True
+    }
+    mod = MultIntensityCorr(input_data=params, args=[])
+    mod.run()
+
+    expected_directory = os.path.join(multiplicative_multichan_correction_example_dir, 'intensity_corrected')
+    output_tilespecs = renderapi.tilespec.get_tile_specs_from_z(
+        output_stack, 400, render=render)
+    for channel in ["DAPI_1","PSD95"]:
+        for ts in output_tilespecs:
+            N, M, out_image = getImage(ts, channel=channel)
+            chan = next(ch for ch in ts.channels if ch.name==channel)
+            out_filepath = chan.ip[0].imageUrl
+            out_file = os.path.split(out_filepath)[1]
+            exp_image = tifffile.imread(os.path.join(expected_directory, out_file))
+            assert(np.max(np.abs(exp_image - out_image)) < 3)
+    return mod
+
+def test_single_tile(test_apply_correction,render,tmpdir):
+
+    # get tilespecs
+    # Z = test_apply_correction.args['z_index']
+    Z = 400
+    inp_tilespecs = renderapi.tilespec.get_tile_specs_from_z(
+        test_apply_correction.args['input_stack'], Z, render=test_apply_correction.render)
+    corr_tilespecs = renderapi.tilespec.get_tile_specs_from_z(
+        test_apply_correction.args['correction_stack'], Z, render=test_apply_correction.render)
+    # mult intensity correct each tilespecs and return tilespecs
+    N, M, C = getImage(corr_tilespecs[0])
+    corr_dict = {}
+    for channel in ["DAPI_1","PSD95"]:
+        _, _, corr_dict[channel] = getImage(corr_tilespecs[0], channel=channel)
+
+	#process_tile(C, corr_dict, dirout, stackname, clip,scale_factor,clip_min,clip_max,input_ts)
+    process_tile(C,
+                 corr_dict,
+                 test_apply_correction.args['output_directory'],
+                 test_apply_correction.args['output_stack'],
+		 True, 1.0,0,65535,
+                 inp_tilespecs[0])

--- a/integration_tests/test_multiplicative_correction.py
+++ b/integration_tests/test_multiplicative_correction.py
@@ -120,8 +120,9 @@ def test_single_tile(test_apply_correction,render,tmpdir):
     # mult intensity correct each tilespecs and return tilespecs
     N, M, C = getImage(corr_tilespecs[0])
 
-	#process_tile(C, dirout, stackname, clip,scale_factor,clip_min,clip_max,input_ts)
+	#process_tile(C, corr_dict, dirout, stackname, clip,scale_factor,clip_min,clip_max,input_ts)
     process_tile(C,
+                 {},
                  test_apply_correction.args['output_directory'],
                  test_apply_correction.args['output_stack'],
 		 True, 1.0,0,65535,

--- a/integration_tests/test_multiplicative_correction.py
+++ b/integration_tests/test_multiplicative_correction.py
@@ -120,9 +120,8 @@ def test_single_tile(test_apply_correction,render,tmpdir):
     # mult intensity correct each tilespecs and return tilespecs
     N, M, C = getImage(corr_tilespecs[0])
 
-	#process_tile(C, corr_dict, dirout, stackname, clip,scale_factor,clip_min,clip_max,input_ts)
+	#process_tile(C, dirout, stackname, clip, scale_factor, clip_min, clip_max, input_ts, corr_dict=None)
     process_tile(C,
-                 {},
                  test_apply_correction.args['output_directory'],
                  test_apply_correction.args['output_stack'],
 		 True, 1.0,0,65535,

--- a/rendermodules/intensity_correction/apply_multiplicative_correction.py
+++ b/rendermodules/intensity_correction/apply_multiplicative_correction.py
@@ -168,8 +168,6 @@ class MultIntensityCorr(StackTransitionModule):
                 corr_dict[chan.name] = CC
         
         outdir = self.args['output_directory']
-        if not os.path.exists(outdir):
-            os.makedirs(outdir)
 
         mypartial = partial(
             process_tile,

--- a/rendermodules/intensity_correction/apply_multiplicative_correction.py
+++ b/rendermodules/intensity_correction/apply_multiplicative_correction.py
@@ -104,7 +104,7 @@ def write_image(dirout, orig_imageurl, Res, stackname, z):
     tifffile.imsave(outImage, Res)
     return outImage
 
-def process_tile_multichan(C, corr_dict, dirout, stackname, clip, scale_factor, clip_min, clip_max, input_ts):
+def process_tile(C, dirout, stackname, clip, scale_factor, clip_min, clip_max, input_ts, corr_dict=None):
     """function to correct each tile in the input_ts with the matrix C,
     and potentially move the original tiles to a new location.abs
 
@@ -144,11 +144,6 @@ def process_tile_multichan(C, corr_dict, dirout, stackname, clip, scale_factor, 
 
     return output_ts
 
-def process_tile(C, dirout, stackname, clip, scale_factor, clip_min, clip_max, input_ts):
-    """function to maintain the existing process_tile prototype"""
-    return process_tile_multichan(C, None, dirout, stackname, clip, scale_factor, clip_min, clip_max, input_ts)
-
-
 class MultIntensityCorr(StackTransitionModule):
     default_schema = MultIntensityCorrParams
 
@@ -177,15 +172,15 @@ class MultIntensityCorr(StackTransitionModule):
             os.makedirs(outdir)
 
         mypartial = partial(
-            process_tile_multichan,
+            process_tile,
             C,
-            corr_dict,
             self.args['output_directory'],
             self.args['output_stack'],
             self.args['clip'],
             self.args['scale_factor'],
             self.args['clip_min'],
-            self.args['clip_max'])
+            self.args['clip_max'],
+            corr_dict=corr_dict)
         with renderapi.client.WithPool(self.args['pool_size']) as pool:
             output_tilespecs = pool.map(mypartial, inp_tilespecs)
 

--- a/rendermodules/intensity_correction/apply_multiplicative_correction.py
+++ b/rendermodules/intensity_correction/apply_multiplicative_correction.py
@@ -7,22 +7,24 @@ import numpy as np
 import tifffile
 from ..module.render_module import RenderModule
 from ..module.render_module import StackTransitionModule
+from ..module.render_module import RenderModuleException
 from rendermodules.intensity_correction.schemas import MultIntensityCorrParams
 from six.moves import urllib
 
+
 example_input = {
     "render": {
-        "host": "ibs-forrestc-ux1",
-        "port": 8080,
-        "owner": "M246930_Scnn1a",
-        "project": "M246930_Scnn1a_4",
-        "client_scripts": "/var/www/render/render-ws-java-client/src/main/scripts"
+        "host": "10.128.24.33",
+        "port": 80,
+        "owner": "multchan",
+        "project": "M335503_Ai139_smallvol",
+        "client_scripts": '/shared/render/render-ws-java-client/src/main/scripts'
     },
-    "input_stack": "Acquisition_DAPI_1",
-    "correction_stack": "Median_TEST_DAPI_1",
-    "output_stack": "Flatfield_TEST_DAPI_1",
-    "output_directory": "/nas/data/M246930_Scnn1a_4/processed/FlatfieldTEST",
-    "z": 102,
+    "input_stack": "TESTAcquisition_Session1",
+    "correction_stack": "TESTMedian_Session1",
+    "output_stack": "TESTFlatfield_Session1",
+    "output_directory": "/nas2/data/M335503_Ai139_smallvol/processed/TESTFlatfield",
+    "z": 501,
     "pool_size": 20
 }
 
@@ -61,7 +63,7 @@ def intensity_corr(img, ff,clip,scale_factor,clip_min,clip_max):
     return result_int
 
 
-def getImage(ts):
+def getImage(ts, channel=None):
     """Simple function to get the level 0 image of this tilespec
     as a numpy array
 
@@ -70,22 +72,39 @@ def getImage(ts):
     ts: renderapi.tilespec.TileSpec
         tilespec to get images from
         (presently assumes this is a tiff image whose URL can be read with tifffile)
-
+    channel: str
+        channel name to get image of, default=None which will default to the non channel image pyramid
     Returns
     =======
     numpy.array
         2d numpy array of this image
     """
-    d = ts.to_dict()
-    mml = ts.ip[0]
+    if channel is None:
+        mml = ts.ip[0]
+    else:
+        if ts.channels is None:
+            raise RenderModuleException('No channels exist for this tilespec (ts.tileId={}'.format(ts.tileId))
+        else:
+            try:
+                chan = next(ch for ch in ts.channels if ch.name==channel)
+                mml = chan.ip[0]
+            except StopIteration as e:
+                raise RenderModuleException('Tilespec {} does not contain channel {}'.format(ts.tileId,channel))
+
     url = urllib.parse.unquote(urllib.parse.urlparse(
         str(mml.imageUrl)).path)
     img0 = tifffile.imread(url)
     (N, M) = img0.shape
     return N, M, img0
 
+def write_image(dirout, orig_imageurl, Res, stackname, z):
+    [head, tail] = os.path.split(orig_imageurl)
+    outImage = os.path.join("%s" % dirout, "%s_%04d_%s" %
+                            (stackname, z, tail))
+    tifffile.imsave(outImage, Res)
+    return outImage
 
-def process_tile(C, dirout, stackname, clip,scale_factor,clip_min,clip_max,input_ts):
+def process_tile(C, corr_dict, dirout, stackname, clip,scale_factor,clip_min,clip_max,input_ts):
     """function to correct each tile in the input_ts with the matrix C,
     and potentially move the original tiles to a new location.abs
 
@@ -93,6 +112,8 @@ def process_tile(C, dirout, stackname, clip,scale_factor,clip_min,clip_max,input
     ==========
     C: numpy.array
         a 2d numpy array of uint16 or uint8 that represents the correction to apply
+    corr_dict: dict
+        a dictionary with keys of strings of channel names and values of corrections (as with C)
     dirout: str
         the path to the directory to save all corrected images
     input_ts: renderapi.tilespec.TileSpec
@@ -100,17 +121,22 @@ def process_tile(C, dirout, stackname, clip,scale_factor,clip_min,clip_max,input
     """
     [N1, M1, I] = getImage(input_ts)
     Res = intensity_corr(I, C, clip, scale_factor, clip_min, clip_max)
-
-    [head, tail] = os.path.split(input_ts.ip[0].imageUrl)
-    outImage = os.path.join("%s" % dirout, "%s_%04d_%s" %
-                            (stackname, input_ts.z, tail))
-    tifffile.imsave(outImage, Res)
-
+    outImage = write_image(dirout, input_ts.ip[0].imageUrl, Res, stackname, input_ts.z)
+    
     output_ts = input_ts
     mm = renderapi.image_pyramid.MipMap(imageUrl=outImage)
-
     output_ts.ip = renderapi.image_pyramid.ImagePyramid()
     output_ts.ip[0] = mm
+
+    if output_ts.channels is not None:
+        for chan in output_ts.channels:
+            [N1, M1, I] = getImage(output_ts, chan.name)
+            CC = corr_dict[chan.name]
+            CRes = intensity_corr(I, CC, clip, scale_factor, clip_min, clip_max)
+            chan_outImage = write_image(dirout, chan.ip[0].imageUrl, CRes, stackname, input_ts.z)
+            mm = renderapi.image_pyramid.MipMap(imageUrl = chan_outImage)
+            chan.ip = renderapi.image_pyramid.ImagePyramid()
+            chan.ip[0]=mm
 
     return output_ts
 
@@ -127,9 +153,31 @@ class MultIntensityCorr(StackTransitionModule):
         corr_tilespecs = renderapi.tilespec.get_tile_specs_from_z(
             self.args['correction_stack'], Z, render=self.render)
         # mult intensity correct each tilespecs and return tilespecs
-        N, M, C = getImage(corr_tilespecs[0])
+        corr_ts = corr_tilespecs[0]
+
+        N, M, C = getImage(corr_ts)
+
+        # construct a dictionary with the correction factors
+        corr_dict = {}
+        if corr_ts.channels is not None:
+            for chan in corr_ts.channels:
+                Nc, Mc, CC = getImage(corr_ts, chan.name)
+                corr_dict[chan.name] = CC
+        
+        outdir = self.args['output_directory']
+        if not os.path.exists(outdir):
+            os.makedirs(outdir)
+
         mypartial = partial(
-            process_tile, C, self.args['output_directory'], self.args['output_stack'],self.args['clip'],self.args['scale_factor'],self.args['clip_min'],self.args['clip_max'])
+            process_tile,
+            C,
+            corr_dict,
+            self.args['output_directory'],
+            self.args['output_stack'],
+            self.args['clip'],
+            self.args['scale_factor'],
+            self.args['clip_min'],
+            self.args['clip_max'])
         with renderapi.client.WithPool(self.args['pool_size']) as pool:
             output_tilespecs = pool.map(mypartial, inp_tilespecs)
 

--- a/rendermodules/intensity_correction/calculate_multiplicative_correction.py
+++ b/rendermodules/intensity_correction/calculate_multiplicative_correction.py
@@ -176,6 +176,3 @@ class MakeMedian(RenderModule):
 if __name__ == "__main__":
     mod = MakeMedian(input_data=example_input)
     mod.run()
-
-
-mylist = [i*i for i in range(5) if i<4]

--- a/rendermodules/intensity_correction/calculate_multiplicative_correction.py
+++ b/rendermodules/intensity_correction/calculate_multiplicative_correction.py
@@ -118,7 +118,6 @@ class MakeMedian(RenderModule):
         outdir = self.args['output_directory']
         if not os.path.exists(outdir):
             os.makedirs(outdir)
-        print("channel_name",channel_names)
         out_images = []
         for chan_name in channel_names:
             chan_str = chan_name if chan_name is not None else ""

--- a/rendermodules/intensity_correction/calculate_multiplicative_correction.py
+++ b/rendermodules/intensity_correction/calculate_multiplicative_correction.py
@@ -103,7 +103,11 @@ class MakeMedian(RenderModule):
 
         stackInfo = renderapi.stack.get_full_stack_metadata(self.args['input_stack'],
                                                             render=self.render)
-        channel_names = stackInfo['stats'].get('channelNames', [None])
+        channel_names = stackInfo['stats'].get('channelNames', [])
+        # Quick fix to have the empty channel logic work when channelNames=[]
+        if len(channel_names) == 0:     
+            channel_names = [None]
+
         #figure out which of our channels is the default channel
         if channel_names[0] is not None:
             try:

--- a/rendermodules/intensity_correction/calculate_multiplicative_correction.py
+++ b/rendermodules/intensity_correction/calculate_multiplicative_correction.py
@@ -12,29 +12,67 @@ from rendermodules.module.render_module import RenderModule
 
 example_input = {
     "render": {
-        "host": "ibs-forrestc-ux1",
-        "port": 8080,
-        "owner": "M246930_Scnn1a",
-        "project": "M246930_Scnn1a_4",
-        "client_scripts": "/var/www/render/render-ws-java-client/src/main/scripts"
+        "host": "10.128.24.33",
+        "port": 80,
+        "owner": "multchan",
+        "project": "M335503_Ai139_smallvol",
+        "client_scripts": '/shared/render/render-ws-java-client/src/main/scripts'
     },
-    "input_stack": "Acquisition_DAPI_1",
+    "input_stack": "ACQ_Session1",
     "file_prefix": "Median",
-    "output_stack": "Median_TEST_DAPI_1",
-    "output_directory": "/nas/data/M246930_Scnn1a_4/processed/Medians",
-    "minZ": 100,
-    "maxZ": 103,
-    "pool_size": 20
+    "output_stack": "TESTMedian_Session1",
+    "output_directory": "/nas2/data/M335503_Ai139_smallvol/processed/TESTMedians",
+    "minZ": 500,
+    "maxZ": 524,
+    "pool_size": 20,
+    "close_stack": True
 }
 
 
-def getImageFromTilespecs(alltilespecs, index):
-    N, M, img = getImage(alltilespecs[index])
+def getImageFromTilespecs(alltilespecs, index, channel=None):
+    N, M, img = getImage(alltilespecs[index], channel)
     return img
 
-def randomly_subsample_tilespecs(alltilespecs,numtiles):
+
+def randomly_subsample_tilespecs(alltilespecs, numtiles):
     np.random.shuffle(alltilespecs)
     return alltilespecs[:numtiles]
+
+# if multichannel stack
+    # loop over each channel
+    # calculate median image
+    # construct a channel
+    # make a tilespec for each z with each of these channels
+
+# make a conventional median stack
+    # calculate a median image
+    # make a tilespec for each z with median image as default image pyramid
+
+
+def make_median_image(alltilespecs, numtiles, outImage, pool_size, chan=None, gauss_size=10):
+    # read images and create stack
+    N, M, img0 = getImage(alltilespecs[0], channel=chan)
+    stack = np.zeros((N, M, numtiles), dtype=img0.dtype)
+    mypartial = partial(getImageFromTilespecs, alltilespecs, channel = chan)
+    indexes = range(0, numtiles)
+    with renderapi.client.WithPool(pool_size) as pool:
+        images = pool.map(mypartial, indexes)
+
+    # calculate median
+    for i in range(0, len(images)):
+        stack[:, :, i] = images[i]
+    np.median(stack, axis=2, overwrite_input=True)
+    (A, B, C) = stack.shape
+    if (numtiles % 2 == 0):
+        med1 = stack[:, :, numtiles // 2 - 1]
+        med2 = stack[:, :, numtiles // 2 + 1]
+        med = (med1 + med2) // 2
+    else:
+        med = stack[:, :, (numtiles - 1) // 2]
+    med = gaussian_filter(med, gauss_size)
+
+    tifffile.imsave(outImage, med)
+
 
 class MakeMedian(RenderModule):
     default_schema = MakeMedianParams
@@ -58,48 +96,65 @@ class MakeMedian(RenderModule):
             # used for easy creation of tilespecs for output stack
             firstts.append(tilespecs[0])
             numtiles += len(tilespecs)
-
-        #subsample in the case where the number of tiles is too large
+        # subsample in the case where the number of tiles is too large
         if self.args['num_images'] > 0:
-            alltilespecs = randomly_subsample_tilespecs(alltilespecs,self.args['num_images'])
+            alltilespecs = randomly_subsample_tilespecs(
+                alltilespecs, self.args['num_images'])
 
-        # read images and create stack
-        N, M, img0 = getImage(alltilespecs[0])
-        stack = np.zeros((N, M, numtiles), dtype=img0.dtype)
-        mypartial = partial(getImageFromTilespecs, alltilespecs)
-        indexes = range(0, numtiles)
-        with renderapi.client.WithPool(self.args['pool_size']) as pool:
-            images = pool.map(mypartial, indexes)
+        stackInfo = renderapi.stack.get_full_stack_metadata(self.args['input_stack'],
+                                                            render=self.render)
+        channel_names = stackInfo['stats'].get('channelNames', [None])
+        #figure out which of our channels is the default channel
+        if channel_names[0] is not None:
+            try:
+                default_chan = next(ch.name for ch in firstts[0].channels if ch.ip[0].imageUrl == firstts[0].ip[0].imageUrl )
+            except StopIteration:
+                raise RenderModuleException("default channel doesn't match any channel")
 
-        # calculate median
-        for i in range(0, len(images)):
-            stack[:, :, i] = images[i]
-        np.median(stack, axis=2, overwrite_input=True)
-        (A, B, C) = stack.shape
-        if (numtiles % 2 == 0):
-            med1 = stack[:, :, numtiles // 2 - 1]
-            med2 = stack[:, :, numtiles // 2 + 1]
-            med = (med1 + med2) // 2
-        else:
-            med = stack[:, :, (numtiles - 1) // 2]
-        med = gaussian_filter(med, 10)
-
-        # save image and create output tilespecs
         outdir = self.args['output_directory']
         if not os.path.exists(outdir):
             os.makedirs(outdir)
+        print("channel_name",channel_names)
+        out_images = []
+        for chan_name in channel_names:
+            chan_str = chan_name if chan_name is not None else ""
+            outImage = outdir + \
+                "/%s_%s_%s_%d-%d.tif" % (self.args['file_prefix'],
+                                        self.args['output_stack'],
+                                        chan_str,
+                                        self.args['minZ'],
+                                        self.args['maxZ'])
+            make_median_image(alltilespecs,
+                              numtiles,
+                              outImage,
+                              self.args['pool_size'],
+                              chan=chan_name)
+            out_images.append(outImage)
 
         for ind, z in enumerate(range(self.args['minZ'], self.args['maxZ'] + 1)):
-            outImage = outdir + \
-                "/%s_%s_%d.tif" % (self.args['file_prefix'],
-                                   self.args['output_stack'], z)
-            tifffile.imsave(outImage, med)
-            ts = firstts[ind]
+            # want many variations on this tilespec so making a copy by serializing/deserializing
+            ts = renderapi.tilespec.TileSpec(json = firstts[ind].to_dict())
+            # want a different z for each one
             ts.z = z
-            mml_o = ts.ip[0]
-            mml = renderapi.image_pyramid.MipMap(
-                 imageUrl=outImage, maskUrl=mml_o.maskUrl)
-            ts.ip[0] = mml
+            if channel_names[0] is None:
+                mml_o = ts.ip[0]
+                mml = renderapi.image_pyramid.MipMap(
+                    imageUrl=out_images[0],
+                    maskUrl=mml_o.maskUrl)
+                ts.ip[0] = mml
+            else:
+                channels = []
+                for chan_name, out_image in zip(channel_names, out_images):
+                    chan_orig = next(ch for ch in ts.channels if ch.name == chan_name)
+                    mml = renderapi.image_pyramid.MipMap(
+                        imageUrl=out_image)
+                    ip = renderapi.image_pyramid.ImagePyramid()
+                    ip[0]=mml
+                    chan_orig.ip = ip
+                    channels.append(chan_orig)
+                # we want the default_chan median to be the default image pyramid 
+                ts.ip = next(med_ch.ip for med_ch in channels if med_ch.name == default_chan)
+                ts.channels = channels
             outtilespecs.append(ts)
 
         # upload to render
@@ -109,11 +164,14 @@ class MakeMedian(RenderModule):
             self.args['output_stack'], "LOADING", render=self.render)
         renderapi.client.import_tilespecs_parallel(
             self.args['output_stack'], outtilespecs,
-            poolsize=self.args['pool_size'],render=self.render,close_stack=self.args['close_stack'])
-        #renderapi.stack.set_stack_state(
+            poolsize=self.args['pool_size'], render=self.render, close_stack=self.args['close_stack'])
+        # renderapi.stack.set_stack_state(
         #    self.args['output_stack'], "COMPLETE", render=self.render)
 
 
 if __name__ == "__main__":
     mod = MakeMedian(input_data=example_input)
     mod.run()
+
+
+mylist = [i*i for i in range(5) if i<4]

--- a/rendermodules/intensity_correction/schemas.py
+++ b/rendermodules/intensity_correction/schemas.py
@@ -1,4 +1,4 @@
-from argschema.fields import Str, Float, Int, Bool
+from argschema.fields import Str, Float, Int, Bool, OutputDir
 from ..module.schemas import StackTransitionParameters
 
 
@@ -13,7 +13,7 @@ class MakeMedianParams(StackTransitionParameters):
 class MultIntensityCorrParams(StackTransitionParameters):
     correction_stack = Str(required=True,
                            description='Correction stack (usually median stack for AT data)')
-    output_directory = Str(required=True,
+    output_directory = OutputDir(required=True,
                                  description='Directory for storing Images')
     # TODO add create_stack metadata
     cycle_number = Int(required=False, default=2,


### PR DESCRIPTION
This is @fcollman's multichannel modifications from August 2018, with a few added tests.

The tests work locally, and we'll see soon if I copied the correct data to the test directory.

I am concerned about one function:
https://github.com/AllenInstitute/render-modules/blob/ep_multichan_tests/rendermodules/intensity_correction/apply_multiplicative_correction.py#L107

`corr_dict` is a new argument, thus breaking any existing use of this function. Is that something to worry about?  (If so, I can move it to the end as corr_dict={}.)