### PR TITLE
Add close_stack to stack.consolidate_transforms

### DIFF
--- a/rendermodules/stack/consolidate_transforms.py
+++ b/rendermodules/stack/consolidate_transforms.py
@@ -18,6 +18,7 @@ example_json = {
     "output_stack": "ROUGHALIGN_LENS_DAPI_1_deconvnew_CONS",
     "transforms_slice": ":",
     "pool_size": 10,
+    "close_stack": True
 }
 
 
@@ -154,6 +155,12 @@ class ConsolidateTransforms(RenderModule):
 
         # self.render.run(
         #     renderapi.client.import_jsonfiles_parallel, outstack, json_files)
+
+        if self.args['close_stack']:
+            renderapi.stack.set_stack_state(
+                outstack,
+                'COMPLETE',
+                render=self.render)
 
         output_d = {
             "output_stack": outstack,

--- a/rendermodules/stack/schemas.py
+++ b/rendermodules/stack/schemas.py
@@ -26,12 +26,13 @@ class ConsolidateTransformsParameters(RenderParameters):
         required=False, default=False,
         description=("whether to remove the existing layer from the "
                      "target stack before uploading."))
-
+    close_stack = Boolean(required=False, default=False)
 
 
 class ConsolidateTransformsOutputParameters(DefaultSchema):
     output_stack = Str(required=True, description="name of output stack")
     numZ = Int(required=True, description="Number of z values processed")
+
 
 
 class MipMapDirectories(DefaultSchema):
@@ -62,7 +63,7 @@ class RemapZsOutput(DefaultSchema):
 
 class SwapZsParameters(RenderParameters):
     source_stack = List(
-        Str, 
+        Str,
         required=True,
         description="List of source stacks")
     target_stack = List(


### PR DESCRIPTION
This was a minor change @TotteKarlsson and I made a while ago to have a close_stack option when consolidating transformations.  (If this belongs elsewhere, please let me know.)