### PR TITLE
Bump EMaligner

### DIFF
--- a/integration_tests/test_em_montage.py
+++ b/integration_tests/test_em_montage.py
@@ -6,6 +6,7 @@ import json
 import glob
 import subprocess
 import mock
+import numpy as np
 from test_data import (RAW_STACK_INPUT_JSON,
                       log_dir,
                       render_params,
@@ -163,12 +164,12 @@ def test_montage_solver(render, raw_stack, test_point_match_generation, tmpdir_f
     mod.run()
     
     precision=1e-7
-    assert mod.module.results['precision'] < precision
-    assert mod.module.results['error'] < 200
+    assert np.all(np.array(mod.module.results['precision']) < precision)
+    assert np.all(np.array(mod.module.results['error'])) < 200
     with open(parameters['output_json'], 'r') as f:
         output_d = json.load(f)
     
     #output_d['stack'] = eval(output_d['stack'])
     #output_d['stack'] = [e.encode('UTF8') for e in output_d['stack']]
-    assert parameters['output_stack']['name'] == output_d['stack']
+    assert parameters['output_stack']['name'][0] == output_d['stack']
 

--- a/integration_tests/test_solver.py
+++ b/integration_tests/test_solver.py
@@ -3,6 +3,7 @@ import renderapi
 import json
 import os
 from rendermodules.solver.solve import Solve_stack
+import numpy as np
 from test_data import (render_params,
                        example_dir,
                        solver_montage_parameters)
@@ -49,11 +50,11 @@ def montage_pointmatches(render):
 def one_solve(parameters, precision=1e-7):
     mod = Solve_stack(input_data=parameters, args=[])
     mod.run()
-    assert mod.module.results['precision'] < precision
-    assert mod.module.results['error'] < 200
+    assert np.all(np.array(mod.module.results['precision']) < precision)
+    assert np.all(np.array(mod.module.results['error']) < 200)
     with open(parameters['output_json'], 'r') as f:
         output_d = json.load(f)
-    assert output_d['stack'] == parameters['output_stack']['name']
+    assert output_d['stack'] == parameters['output_stack']['name'][0]
 
 
 def test_solver_montage_test(render, montage_pointmatches, raw_stack, tmpdir):

--- a/rendermodules/solver/solve.py
+++ b/rendermodules/solver/solve.py
@@ -73,7 +73,7 @@ class Solve_stack(argschema.ArgSchemaParser):
         self.module = EMaligner.EMaligner(input_data=self.args, args=[])
         self.module.run()
         self.output(
-            {"stack": self.args['output_stack']['name']})
+            {"stack": self.args['output_stack']['name'][0]})
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ scipy
 rtree
 networkx
 bokeh
-EMaligner==0.3.2
+EMaligner==1.0.0
 matplotlib
 opencv-contrib-python<3.4.3.0
 jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-render-python==2.1.1
+render-python==2.2.1
 argschema>=1.15.17
 numpy
 pillow


### PR DESCRIPTION
Render-modules has been using EM_aligner_python v0.3.2 from October 2018. This PR brings render-modules up to using the latest release, v1.0.0. Everything should be backwards-compatible for input_jsons. Numerically, results should be the same. There have been a couple of changes since Oct '18 that I tweaked here, which I think really only effect tests in this repo.
1) The solver object has attribute `results` which contains keys `precision` and `error`. Instead of single float values, these are now lists of float values, to reflect the fact that the solver is actually performing separate solved for x and y (unless fullsize affine transform is specified for some reason, which we don't). I modified the tests to deal with this.
2) At some point, we added the ability to specify more than one pointmatch collection into the solver. The schemas for pointmatch can take a list of names instead of just one name, and, in the case of a single string supplied, they actually preprocess this into a single-element list. input_stack and output_stack share with pointmatch the same database interface schema base. As a result, after the aligner has processed input arguments, something that was `args['output_stack']['name'] = "mystack"` is now `args['output_stack']['name'] = ["mystack"]`. I modified the tests to deal with this.