### PR TITLE
making qc html file names informative

### DIFF
--- a/rendermodules/em_montage_qc/plots.py
+++ b/rendermodules/em_montage_qc/plots.py
@@ -2,6 +2,8 @@ import numpy as np
 import tempfile
 import renderapi
 import requests
+import os
+import datetime
 from functools import partial
 
 from rendermodules.residuals import compute_residuals as cr
@@ -136,10 +138,14 @@ def plot_defects(render, stack, out_html_dir, args):
         #else:
         #    residual.append(50) # a high value for residual for that tile
 
-    out_html = tempfile.NamedTemporaryFile(suffix=".html", delete=False, mode='w', dir=out_html_dir)
-    out_html.close()
+    out_html = os.path.join(
+            out_html_dir,
+            "%s_%d_%s.html" % (
+                stack,
+                z,
+                datetime.datetime.now().strftime('%Y%m%d%H%S%M%f')))
 
-    output_file(out_html.name)
+    output_file(out_html)
     xs = []
     ys = []
     alphas = []
@@ -220,7 +226,7 @@ def plot_defects(render, stack, out_html_dir, args):
 
     save(plot_tabs)
 
-    return out_html.name
+    return out_html
 
 
 def plot_section_maps(render, stack, post_tspecs, matches, disconnected_tiles, gap_tiles, seam_centroids, stats, zvalues, out_html_dir=None, pool_size=5):


### PR DESCRIPTION
I think this will help communicating qc results on slack, and just general readability.
currently, qc output html files are name like:
`<out_html_dir>/tmpyc_ynqzh.html`
especially when debugging manually, one can get a directory full of these and it would be nice to easily pick out what section from the name.
This PR replaces with:
`<out_html_dir>/<stack>_<z>_<timestamp>.html`
`stack` and `z` are already known to the function that writes the files. `timestamp` is a millisecond-precision datetime.now() string just in case multiple nodes are writing output files for the same stack/z to the same directory. (generally probably not)