### PR TITLE
exposing matchFilter to spark point match client

### DIFF
--- a/rendermodules/module/schemas/renderclient_schemas.py
+++ b/rendermodules/module/schemas/renderclient_schemas.py
@@ -169,6 +169,13 @@ class MatchDerivationParameters(argschema.schemas.DefaultSchema):
         "Maximum trust for filtering such that candidates with cost larger "
         "than matchMaxTrust * median cost are rejected. "
         "3.0 if excluded or None"))
+    matchFilter = Str(
+            required=False,
+            validator=validate.OneOf(
+            ['SINGLE_SET', 'CONSENSUS_SETS', 'AGGREGATED_CONSENSUS_SETS']),
+            description=("whether to match one set of matches, or multiple "
+                " sets. And, whether to keep them separate, or aggregate them. "
+                "SINGLE_SET if excluded or None."))
 
 
 class MatchWebServiceParameters(WebServiceParameters):

--- a/rendermodules/pointmatch/generate_point_matches_spark.py
+++ b/rendermodules/pointmatch/generate_point_matches_spark.py
@@ -96,6 +96,7 @@ class PointMatchClientModuleSpark(SparkModule):
                             rootFeatureDirectory=None,
                             renderFilterListName=None,
                             requireStoredFeatures=None,
+                            matchFilter=None,
                             **kwargs):
         get_cmd_opt = cls.get_cmd_opt
         cmd = (
@@ -111,6 +112,7 @@ class PointMatchClientModuleSpark(SparkModule):
             get_cmd_opt(matchModelType, '--matchModelType') +
             get_cmd_opt(matchIterations, '--matchIterations') +
             get_cmd_opt(matchMaxEpsilon, '--matchMaxEpsilon') +
+            get_cmd_opt(matchFilter, '--matchFilter') +
             get_cmd_opt(matchMinInlierRatio, '--matchMinInlierRatio') +
             get_cmd_opt(matchMinNumInliers, '--matchMinNumInliers') +
             get_cmd_opt(matchMaxNumInliers, '--matchMaxNumInliers') +


### PR DESCRIPTION
exposes this feature:
https://github.com/saalfeldlab/render/blob/c3b4e95d02f642916eba9edceacf60857442aa35/render-app/src/main/java/org/janelia/alignment/match/CanvasFeatureMatcher.java#L105-L123

can help match across folds and cracks, for example
