### PR TITLE
Label lens tform

### DIFF
--- a/integration_tests/test_lens_correction.py
+++ b/integration_tests/test_lens_correction.py
@@ -171,7 +171,8 @@ def test_apply_lens_correction(render, stack_no_lc, stack_lc,
         "transform": example_tform_dict,
         "refId": None,
         "pool_size": 5,
-        "overwrite_zlayer": True
+        "overwrite_zlayer": True,
+        "labels": ["lens"]
     }
 
     out_fn = 'test_ALC_out.json'
@@ -199,6 +200,7 @@ def test_apply_lens_correction(render, stack_no_lc, stack_lc,
         new_tform = tforms[0]
         print(new_tform.to_dict())
         assert new_tform.transformId == refId
+        assert new_tform.labels == params['labels']
         assert np.array_equal(
             [example_tform.height, example_tform.width, example_tform.length,
                 example_tform.dimension],

--- a/integration_tests/test_lens_correction.py
+++ b/integration_tests/test_lens_correction.py
@@ -210,6 +210,34 @@ def test_apply_lens_correction(render, stack_no_lc, stack_lc,
         compute_lc_norm_and_max(test_example_tform, test_new_tform)
 
 
+def test_label_append(render, stack_no_lc, stack_lc,
+                               example_tform_dict, test_points):
+    params = {
+        "render": render_params,
+        "inputStack": stack_no_lc,
+        "outputStack": stack_lc,
+        "zs": [2266],
+        "transform": dict(example_tform_dict),
+        "refId": None,
+        "pool_size": 5,
+        "overwrite_zlayer": True,
+        "labels": ["lens"]
+    }
+
+    params['transform']['metadata'] = {'labels': ['something']}
+
+    out_fn = 'test_ALC_out2.json'
+    mod = ApplyLensCorrection(input_data=params,
+                              args=['--output_json', out_fn])
+    mod.run()
+
+    for z in params['zs']:
+        resolvedtiles = renderapi.resolvedtiles.get_resolved_tiles_from_z(
+            params['output_stack'], z, render=render)
+        assert 'something' in resolvedtiles.transforms[0].labels
+        assert 'lens' in resolvedtiles.transforms[0].labels
+
+
 def test_apply_lens_correction_mask(
         render, stack_no_lc, stack_lc,
         example_tform_dict, test_points, tmpdir_factory):

--- a/rendermodules/lens_correction/apply_lens_correction.py
+++ b/rendermodules/lens_correction/apply_lens_correction.py
@@ -79,6 +79,12 @@ class ApplyLensCorrection(StackTransitionModule):
         lc_tform.transformId = refId
         ref_lc = renderapi.transform.ReferenceTransform(
             refId=lc_tform.transformId)
+        if lc_tform.labels is None:
+            lc_tform.labels = self.args['labels']
+        else:
+            for label in self.args['labels']:
+                if label not in lc_tform.labels:
+                    lc_tform.labels.append(label)
 
         tspecs = renderapi.tilespec.get_tile_specs_from_z(
             self.input_stack, self.zValues[0], render=r)

--- a/rendermodules/lens_correction/schemas.py
+++ b/rendermodules/lens_correction/schemas.py
@@ -25,6 +25,12 @@ class ApplyLensCorrectionParameters(StackTransitionParameters):
         allow_none=True, required=True,
         description=('Reference ID to use when uploading transform to '
                      'render database (Not Implemented)'))
+    labels = List(
+        Str,
+        required=True,
+        missing=['lens'],
+        default=['lens'],
+        description="labels for the lens correction transform")
     maskUrl = InputFile(
             required=False,
             default=None,

--- a/rendermodules/lens_correction/schemas.py
+++ b/rendermodules/lens_correction/schemas.py
@@ -1,5 +1,5 @@
 from argschema import ArgSchema
-from argschema.fields import Bool, Float, Int, Nested, Str, InputFile, List
+from argschema.fields import Bool, Float, Int, Nested, Str, InputFile, List, Dict
 from argschema.schemas import DefaultSchema
 from marshmallow.validate import OneOf
 from rendermodules.module.schemas import StackTransitionParameters
@@ -17,6 +17,9 @@ class TransformParameters(DefaultSchema):
     dataString = Str(
         required=True,
         description='mpicbg-compatible dataString')
+    metaData = Dict(
+        required=False,
+        description="in this schema, otherwise will be stripped")
 
 
 class ApplyLensCorrectionParameters(StackTransitionParameters):


### PR DESCRIPTION
when we pointmatch for montaging, our tilespecs have a transform list that looks like:
```
[ReferenceTransform(5c1529edb83474000163e84b),
 M=[[1.000000,0.000000],[0.000000,1.000000]] B=[216535.000000,231299.000000]]
```
and neither of our transforms are labelled. Somewhere deep in render, it just lops off the last transform and pointmatches in lens-corrected units. For example, here:
https://github.com/saalfeldlab/render/blob/907850047cc4ad22493754464d538cd31920ba52/render-app/src/main/java/org/janelia/alignment/spec/ListTransformSpec.java#L173-L222

For rough alignment, we typically have just one transform, and matching happens in raw units, which we want.

For fine alignment, or a more general case, we could have more than 2 transforms. Then, the matching gets screwed up. The simple fix is to label the lens correction transform as "lens" and then matching happens again in lens corrected space. This PR labels the lens correction transform as "lens" at the time of ApplyLensCorrection.
