### PR TITLE
make montage scape tileIds

### DIFF
--- a/rendermodules/dataimport/make_montage_scapes_stack.py
+++ b/rendermodules/dataimport/make_montage_scapes_stack.py
@@ -2,6 +2,8 @@ import errno
 from functools import partial
 import glob
 import os
+import uuid
+
 import numpy as np
 import pathlib2 as pathlib
 import renderapi

--- a/rendermodules/dataimport/make_montage_scapes_stack.py
+++ b/rendermodules/dataimport/make_montage_scapes_stack.py
@@ -55,10 +55,10 @@ example = {
 }
 '''
 
-
 def create_montage_scape_tile_specs(render, input_stack, image_directory,
                                     scale, project, tagstr, imgformat,
-                                    Z, apply_scale=False, **kwargs):
+                                    Z, apply_scale=False, uuid_prefix_length=10,
+                                    **kwargs):
     z = Z[0]
     newz = Z[1]
 
@@ -120,6 +120,10 @@ def create_montage_scape_tile_specs(render, input_stack, image_directory,
     # generate tilespec for downsampled montage
     # tileId is the first tileId from source z
     t = tilespecs[0]
+
+    t.tileId = "ds{uid}_{tId}".format(
+        uid=uuid.uuid4().hex[:uuid_prefix_length],
+        tId=t.tileId)
 
     with Image.open(filename) as im:
         t.width, t.height = im.size

--- a/rendermodules/dataimport/make_montage_scapes_stack.py
+++ b/rendermodules/dataimport/make_montage_scapes_stack.py
@@ -59,7 +59,8 @@ example = {
 
 def create_montage_scape_tile_specs(render, input_stack, image_directory,
                                     scale, project, tagstr, imgformat,
-                                    Z, apply_scale=False, uuid_prefix_length=10,
+                                    Z, apply_scale=False, uuid_prefix=True,
+                                    uuid_prefix_length=10,
                                     **kwargs):
     z = Z[0]
     newz = Z[1]
@@ -123,9 +124,10 @@ def create_montage_scape_tile_specs(render, input_stack, image_directory,
     # tileId is the first tileId from source z
     t = tilespecs[0]
 
-    t.tileId = "ds{uid}_{tId}".format(
-        uid=uuid.uuid4().hex[:uuid_prefix_length],
-        tId=t.tileId)
+    if uuid_prefix:
+        t.tileId = "ds{uid}_{tId}".format(
+            uid=uuid.uuid4().hex[:uuid_prefix_length],
+            tId=t.tileId)
 
     with Image.open(filename) as im:
         t.width, t.height = im.size
@@ -279,6 +281,8 @@ class MakeMontageScapeSectionStack(StackOutputModule):
             pool_size=1,
             doFilter=self.args['doFilter'],
             fillWithNoise=self.args['fillWithNoise'],
+            uuid_prefix=self.args["uuid_prefix"],
+            uuid_prefix_length=self.args["uuid_length"],
             do_mp=False)
 
         with renderapi.client.WithPool(

--- a/rendermodules/dataimport/schemas.py
+++ b/rendermodules/dataimport/schemas.py
@@ -214,6 +214,11 @@ class MakeMontageScapeSectionStackParameters(OutputStackParameters):
         "number of processes to generate missing downsamples"))
     filterListName = Str(required=False, description=(
         "Apply specified filter list to all renderings"))
+    uuid_prefix = Boolean(
+        required=False, default=True, description=(
+            "Prepend uuid to generated tileIds to prevent collisions"))
+    uuid_length = Int(required=False, default=10, description=(
+        "length of uuid4 string used in uuid prefix"))
 
     @post_load
     def validate_data(self, data):


### PR DESCRIPTION
prepends a shortened uuid to the montage scape tileId which should make it easier to rerun pointmatches on downsampled sections (giving the option to skip these in tilepair generation)